### PR TITLE
Adding armv8l architecture

### DIFF
--- a/src/bin/platforms/linux.ts
+++ b/src/bin/platforms/linux.ts
@@ -344,6 +344,7 @@ export class LinuxInstaller extends BasePlatform {
       case 'aarch64':
         downloadUrl = `https://nodejs.org/dist/${job.target}/node-${job.target}-linux-arm64.tar.gz`;
         break;
+      case 'armv8l':
       case 'armv7l':
         downloadUrl = `https://nodejs.org/dist/${job.target}/node-${job.target}-linux-armv7l.tar.gz`;
         break;


### PR DESCRIPTION
According to https://stackoverflow.com/a/73696522 the armv8l Architecture is a 32 Bit OS running on a 64 Bit CPU. In this case we also need to download the 32 Bit nodejs version.