### PR TITLE
fix: `update-node` cases for RPi 4B

### DIFF
--- a/src/bin/platforms/linux.ts
+++ b/src/bin/platforms/linux.ts
@@ -342,7 +342,13 @@ export class LinuxInstaller extends BasePlatform {
         downloadUrl = `https://nodejs.org/dist/${job.target}/node-${job.target}-linux-x64.tar.gz`;
         break;
       case 'aarch64':
-        downloadUrl = `https://nodejs.org/dist/${job.target}/node-${job.target}-linux-arm64.tar.gz`;
+        // With the latest Raspberry Pi OS upgrades, the Raspberry Pi 4B now runs the 64-bit kernel, even on the 32-bit OS
+        // https://github.com/homebridge/homebridge/issues/3349#issuecomment-1523832510
+        if (child_process.execSync('getconf LONG_BIT')?.toString()?.trim() === '32') {
+          downloadUrl = `https://nodejs.org/dist/${job.target}/node-${job.target}-linux-armv7l.tar.gz`;
+        } else { // + case '64':
+          downloadUrl = `https://nodejs.org/dist/${job.target}/node-${job.target}-linux-arm64.tar.gz`;
+        }
         break;
       case 'armv7l':
         downloadUrl = `https://nodejs.org/dist/${job.target}/node-${job.target}-linux-armv7l.tar.gz`;


### PR DESCRIPTION
> With the latest Raspberry Pi OS upgrades, the Raspberry Pi 4B now runs the 64-bit kernel, even on the 32-bit OS
> https://github.com/homebridge/homebridge/issues/3349#issuecomment-1523832510

Thanks to @ebaauw for the findings and solution

See https://github.com/oznu/homebridge-config-ui-x/pull/1481 for original commit

@NorthernMan54