### PR TITLE
Fix duplicate ignorePatterns in eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     "ui/",
     'ui/**/*',
     'dist/**/*',
+    '.eslintrc.js'
   ],
   plugins: ['@typescript-eslint/eslint-plugin'],
   extends: [
@@ -20,7 +21,6 @@ module.exports = {
     node: true,
     jest: true,
   },
-  ignorePatterns: ['.eslintrc.js'],
   rules: {
     'quotes': ['error', 'single'],
     'comma-dangle': ['error', 'only-multiline'],

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "start": "ts-node -r tsconfig-paths/register src/main.ts",
     "serve": "npm run watch",
     "lint": "npm run lint:server && npm run lint:ui",
-    "lint:server": "eslint \"{src,test}/**/*.ts\" --max-warnings=0 --ignore-pattern \"ui\"",
+    "lint:server": "eslint \"{src,test}/**/*.ts\" --max-warnings=0",
     "lint:ui": "npm run lint --prefix ui",
     "webpack": "webpack --config webpack.config.js",
     "install:ui": "npm install --prefix ui",


### PR DESCRIPTION
## :recycle: Current situation

The `ignorePatterns` config was duplicated in the `.eslintrc` config file, resulting in workarounds like here: https://github.com/homebridge/homebridge-config-ui-x/commit/8e1dc5567297bd71ecd9701780cfc8f1a0d78cb7

## :bulb: Proposed solution

This PR fixes the duplicate property and merges the two, removing the need for the command line argument.

## :gear: Release Notes

* Fixed minor issue in project configuration

## :heavy_plus_sign: Additional Information

### Testing

--

### Reviewer Nudging

Easy to review.
