### PR TITLE
Wait for custom UI

### DIFF
--- a/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.component.ts
+++ b/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.component.ts
@@ -123,9 +123,6 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
     this.iframe = this.customPluginUiElementTarget.nativeElement as HTMLIFrameElement;
     this.iframe.src = environment.api.base + this.basePath +
       '/index.html?origin=' + encodeURIComponent(location.origin) + '&v=' + encodeURIComponent(this.plugin.installedVersion);
-    this.iframe.onload = () => {
-      this.uiLoaded = true;
-    };
   }
 
   handleMessage = (e: MessageEvent) => {
@@ -134,6 +131,7 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
         case 'loaded':
           this.injectDefaultStyles(e);
           this.confirmReady(e);
+          this.uiLoaded = true;
           break;
         case 'request': {
           this.handleRequest(e);


### PR DESCRIPTION
## :recycle: Current situation

The https://github.com/homebridge/homebridge-config-ui-x/pull/1522 fix can sometimes be called too early.

## :bulb: Proposed solution

Set `uiLoaded` after the `loaded` message event.
