### PR TITLE
Wait for custom UI

### DIFF
--- a/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.component.ts
+++ b/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.component.ts
@@ -131,7 +131,6 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
         case 'loaded':
           this.injectDefaultStyles(e);
           this.confirmReady(e);
-          this.uiLoaded = true;
           break;
         case 'request': {
           this.handleRequest(e);
@@ -139,6 +138,7 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
         }
         case 'scrollHeight':
           this.setiFrameHeight(e);
+          this.uiLoaded = true;
           break;
         case 'config.get': {
           this.requestResponse(e, this.getConfigBlocks());


### PR DESCRIPTION
## :recycle: Current situation

The https://github.com/homebridge/homebridge-config-ui-x/pull/1522 fix can still sometimes be called too early.

## :bulb: Proposed solution

Set `uiLoaded` after the `scrollHeight` message event.
