### PR TITLE
Resolve issues with GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,9 @@ jobs:
 
     uses: homebridge/.github/.github/workflows/nodejs-build-and-test.yml@main
     with:
-      enable_coverage: true
+      enable_coverage: false
+      ## Code Coverage can only be used in a single run, not in a parallel run - Error: Bad response: 422 {"message":"Can't add a job to a build that is already closed. Build 6224987022 is closed. See docs.coveralls.io/parallel-builds","error":true}
+      ## Coveralls only expects to create a report once per build
       runs_on: ${{ matrix.os }}
       install_cmd: npm ci && cd ui && npm ci
     secrets:


### PR DESCRIPTION
## :recycle: Current situation

Github Actions fail with `Error: Bad response: 422 {"message":"Can't add a job to a build that is already closed. Build 6224987022 is closed. See docs.coveralls.io/parallel-builds","error":true}`

## :bulb: Proposed solution

After investigating, determined that parallel builds calling `nodejs-build-and-test.yml` with coverage testing enabled triggered the issue, as coveralls expects to have ` parallel-finished: true` called once per build.

## :gear: Release Notes

*Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features.*

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
