### PR TITLE
Fix issues with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,20 +29,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [18.x, 20.x]
+        node-version: [18.x]
         include:
           - os: macos-latest
             node-version: 18.x
-          - os: macos-latest
-            node-version: 20.x
           - os: windows-2019
             node-version: 18.x
-          - os: windows-2019
-            node-version: 20.x
           - os: windows-latest
             node-version: 18.x
-          - os: windows-latest
-            node-version: 20.x
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,9 @@ jobs:
 
     uses: homebridge/.github/.github/workflows/nodejs-build-and-test.yml@main
     with:
-      enable_coverage: true
+      enable_coverage: false
+      ## Code Coverage can only be used in a single run, not in a parallel run - Error: Bad response: 422 {"message":"Can't add a job to a build that is already closed. Build 6224987022 is closed. See docs.coveralls.io/parallel-builds","error":true}
+      ## Coveralls only expects to create a report once per build
       runs_on: ${{ matrix.os }}
       install_cmd: npm ci && cd ui && npm ci
     secrets:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,25 +7,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [18.x, 20.x]
+        node-version: [18.x]
         include:
           - os: macos-latest
             node-version: 18.x
-          - os: macos-latest
-            node-version: 20.x
           - os: windows-2019
             node-version: 18.x
-          - os: windows-2019
-            node-version: 20.x
           - os: windows-latest
             node-version: 18.x
-          - os: windows-latest
-            node-version: 20.x
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}

--- a/src/bin/platforms/win32.ts
+++ b/src/bin/platforms/win32.ts
@@ -146,7 +146,7 @@ export class Win32Installer extends BasePlatform {
    * This is used to create the Windows Services
    */
   private async downloadNssm(): Promise<string> {
-    const downloadUrl = `https://github.com/homebridge/nssm/releases/download/2.24-101-g897c7ad/nssm_${os.arch()}.exe`;
+    const downloadUrl = `https://github.com/oznu/nssm/releases/download/2.24-101-g897c7ad/nssm_${os.arch()}.exe`;
     const nssmPath = path.resolve(this.hbService.storagePath, 'nssm.exe');
 
     if (await fs.pathExists(nssmPath)) {


### PR DESCRIPTION
## :recycle: Current situation

Github Actions fail with `Error: Bad response: 422 {"message":"Can't add a job to a build that is already closed. Build 6224987022 is closed. See docs.coveralls.io/parallel-builds","error":true}`

Node 20 builds are failing
Windows builds are failing

## :bulb: Proposed solution

Temporarily removed Node 20 builds from the GitHub actions
Corrected location of nssm to resolve Windows builds
And turned off coveralls coverage reporting

## :gear: Release Notes

*Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features.*

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
