### PR TITLE
Fix for CSP Errors

### DIFF
--- a/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.service.ts
+++ b/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.service.ts
@@ -35,7 +35,7 @@ export class PluginsSettingsUiService {
     @Inject(PluginsService) private readonly pluginsService: PluginsService,
     @Inject(ConfigService) private readonly configService: ConfigService,
     @Inject(HttpService) private readonly httpService: HttpService,
-  ) {}
+  ) { }
 
   /**
    * Serve Custom HTML Assets for a plugin
@@ -79,15 +79,19 @@ export class PluginsSettingsUiService {
         // #2873.  frame-ancestors restricts embedding to same-origin
         // frames only, preventing the plugin iframe from being embedded by
         // third-party pages.
+        const extraDomains = pluginUi.customUiCspDomains?.length
+          ? ` ${pluginUi.customUiCspDomains.join(' ')}`
+          : ''
         reply.header(
           'Content-Security-Policy',
           `default-src 'self' ${safeOrigin}; `
-          + `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${safeOrigin}; `
+          + `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${safeOrigin}${extraDomains}; `
           + `style-src 'self' 'unsafe-inline' ${safeOrigin}; `
           + `img-src * data:; `
           + `connect-src *; `
           + `font-src 'self' data:; `
-          + `frame-ancestors 'self' ${safeOrigin}`,
+          + `frame-ancestors 'self' ${safeOrigin}; `
+          + `frame-src 'self' ${safeOrigin}${extraDomains}`,
         )
         return reply
           .type('text/html')

--- a/src/modules/plugins/plugins.interfaces.ts
+++ b/src/modules/plugins/plugins.interfaces.ts
@@ -63,6 +63,7 @@ export interface HomebridgePluginUiMetadata {
   publicPath: string
   serverPath: string
   plugin: HomebridgePlugin
+  customUiCspDomains: string[]
 }
 
 export interface HomebridgePluginVersions {

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -1533,7 +1533,7 @@ export class PluginsService {
         try {
           const release = await firstValueFrom(this.httpService.get(`https://api.github.com/repos/${owner}/${repo}/releases/tags/${tag}`))
           return release.data
-        } catch {}
+        } catch { }
       }
       return null
     }
@@ -1549,7 +1549,7 @@ export class PluginsService {
         }))
         const matched = response.data.filter((b: any) => b.name.includes(keyword))
         return matched.length > 0 ? matched.at(-1).name : null
-      } catch {}
+      } catch { }
       return null
     }
 
@@ -1570,20 +1570,20 @@ export class PluginsService {
               try {
                 const changelog = await firstValueFrom(this.httpService.get(`https://raw.githubusercontent.com/homebridge/${pluginName}/refs/heads/${branch}/CHANGELOG.md`))
                 changelogData = changelog.data
-              } catch {}
+              } catch { }
             }
           }
           if (!changelogData && tag) {
             try {
               const changelog = await firstValueFrom(this.httpService.get(`https://raw.githubusercontent.com/homebridge/${pluginName}/refs/tags/${tag}/CHANGELOG.md`))
               changelogData = changelog.data
-            } catch {}
+            } catch { }
           }
           if (!changelogData) {
             try {
               const changelog = await firstValueFrom(this.httpService.get(`https://raw.githubusercontent.com/homebridge/${pluginName}/HEAD/CHANGELOG.md`))
               changelogData = changelog.data
-            } catch {}
+            } catch { }
           }
 
           return {
@@ -1634,7 +1634,7 @@ export class PluginsService {
             try {
               const changelog = await firstValueFrom(this.httpService.get(`https://raw.githubusercontent.com/${match[1]}/${match[2]}/${ref}/${changelogPath}${filename}`))
               return changelog.data
-            } catch {}
+            } catch { }
           }
           return null
         }
@@ -1895,6 +1895,7 @@ export class PluginsService {
 
     const schema = await readJson(resolve(fullPath, 'config.schema.json'))
     const customUiPath = resolve(fullPath, schema.customUiPath || 'homebridge-ui')
+    const customUiCspDomains = this.sanitizeCspDomains(schema.customUiCspDomains)
 
     const publicPath = resolve(customUiPath, 'public')
     const serverPath = resolve(customUiPath, 'server.js')
@@ -1914,6 +1915,7 @@ export class PluginsService {
         serverPath,
         publicPath,
         plugin,
+        customUiCspDomains,
       }
     }
 
@@ -2753,5 +2755,16 @@ export class PluginsService {
       this.pluginListRetryTimeout = setTimeout(() => this.loadPluginList(), 60000)
       this.logger.debug(`Could not obtain plugin list from plugins repo as ${e.message}.`)
     }
+  }
+
+  private sanitizeCspDomains(domains: unknown): string[] {
+    if (!Array.isArray(domains)) {
+      return []
+    }
+    // Only allow https://<domain>.<tld> style domains, no paths or query strings
+    const RE_VALID_CSP_DOMAIN = /^https:\/\/[a-z0-9-]+(?:\.[a-z0-9-]+)+$/i
+    return domains
+      .filter((d): d is string => typeof d === 'string' && RE_VALID_CSP_DOMAIN.test(d))
+      .slice(0, 10) // hard cap to stop a runaway/malicious schema
   }
 }

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -14,6 +14,7 @@ import type {
   PluginListNewScopeItem,
 } from './plugins.interfaces.js'
 
+import { Buffer } from 'node:buffer'
 import { execSync, fork, spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import { constants, existsSync } from 'node:fs'
@@ -2764,7 +2765,16 @@ export class PluginsService {
     // Only allow https://<domain>.<tld> style domains, no paths or query strings
     const RE_VALID_CSP_DOMAIN = /^https:\/\/[a-z0-9-]+(?:\.[a-z0-9-]+)+$/i
     return domains
-      .filter((d): d is string => typeof d === 'string' && RE_VALID_CSP_DOMAIN.test(d))
+      .filter((d): d is string => {
+        if (typeof d !== 'string') {
+          return false
+        }
+        if (Buffer.byteLength(d, 'utf8') > 256) {
+          this.logger.error('Ignoring customUiCspDomains entry longer than 256 bytes.')
+          return false
+        }
+        return RE_VALID_CSP_DOMAIN.test(d)
+      })
       .slice(0, 10) // hard cap to stop a runaway/malicious schema
   }
 }

--- a/test/e2e/plugin-settings-ui.e2e-spec.ts
+++ b/test/e2e/plugin-settings-ui.e2e-spec.ts
@@ -17,6 +17,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 import { AuthModule } from '../../src/core/auth/auth.module.js'
 import { PluginsSettingsUiModule } from '../../src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.module.js'
 import { PluginsSettingsUiService } from '../../src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.service.js'
+import { PluginsService } from '../../src/modules/plugins/plugins.service.js'
 
 import '../../src/global-defaults.js'
 
@@ -171,6 +172,42 @@ describe('PluginsSettingsUiController (e2e)', () => {
     // evaluate expressions at runtime (e.g. Alpine.js, Vue) need this (#2873)
     expect(csp).toContain('\'unsafe-eval\'')
     expect(csp).toContain('frame-ancestors')
+  })
+
+  it('GET /plugins/settings-ui/:plugin-name/index.html ignores customUiCspDomains entries longer than 256 bytes', async () => {
+    const { readJson, writeJson } = await import('fs-extra')
+
+    const baseSchemaPath = resolve(pluginsPath, 'homebridge-mock-plugin', 'config.schema.json')
+    const baseSchema = await readJson(baseSchemaPath)
+    const maxLengthDomain = `https://${'a'.repeat(244)}.com`
+    const overLengthDomain = `https://${'b'.repeat(245)}.com`
+    const pluginsService = app.get(PluginsService)
+    const loggerErrorSpy = vi.spyOn((pluginsService as any).logger, 'error').mockImplementation(() => undefined)
+
+    try {
+      await writeJson(baseSchemaPath, {
+        ...baseSchema,
+        customUiCspDomains: [maxLengthDomain, overLengthDomain],
+      })
+      ;(app.get(PluginsSettingsUiService) as any).pluginUiMetadataCache.del('homebridge-mock-plugin')
+      ;(app.get(PluginsSettingsUiService) as any).pluginUiLastVersionCache.del('homebridge-mock-plugin')
+
+      const res = await app.inject({
+        method: 'GET',
+        path: '/plugins/settings-ui/homebridge-mock-plugin/index.html',
+        headers: { cookie: sessionCookie },
+      })
+
+      expect(res.statusCode).toBe(200)
+      const csp = res.headers['content-security-policy'] as string
+      expect(csp).toContain(maxLengthDomain)
+      expect(csp).not.toContain(overLengthDomain)
+      expect(loggerErrorSpy).toHaveBeenCalledWith('Ignoring customUiCspDomains entry longer than 256 bytes.')
+    } finally {
+      await writeJson(baseSchemaPath, baseSchema)
+      ;(app.get(PluginsSettingsUiService) as any).pluginUiMetadataCache.del('homebridge-mock-plugin')
+      ;(app.get(PluginsSettingsUiService) as any).pluginUiLastVersionCache.del('homebridge-mock-plugin')
+    }
   })
 
   it('GET /plugins/settings-ui/:plugin-name/index.html (set origin)', async () => {


### PR DESCRIPTION
The recent changes to CSP handling for Custom Plugins has stopped scripts from being supported.  This changes adds a new plugin config.schema.json option `customUiCspDomains` to allow setting trusted domains for script sources.

ie

```
  "customUiCspDomains": [
    "https://www.paypal.com",
    "https://www.paypalobjects.com"
  ],
```