### PR TITLE
Cleaner origin fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2145,6 +2145,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2162,6 +2165,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2179,6 +2185,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2196,6 +2205,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2213,6 +2225,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2230,6 +2245,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2247,6 +2265,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2264,6 +2285,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2466,6 +2490,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2483,6 +2510,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2500,6 +2530,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2517,6 +2550,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2534,6 +2570,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2551,6 +2590,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2808,6 +2850,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2826,6 +2871,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2844,6 +2892,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2862,6 +2913,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2880,6 +2934,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2898,6 +2955,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7751,6 +7811,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7772,6 +7835,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7793,6 +7859,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7814,6 +7883,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2145,9 +2145,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2165,9 +2162,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2185,9 +2179,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2205,9 +2196,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2225,9 +2213,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2245,9 +2230,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2265,9 +2247,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2285,9 +2264,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2490,9 +2466,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2510,9 +2483,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2530,9 +2500,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2550,9 +2517,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2570,9 +2534,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2590,9 +2551,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2850,9 +2808,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2871,9 +2826,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2892,9 +2844,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2913,9 +2862,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2934,9 +2880,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2955,9 +2898,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7811,9 +7751,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7835,9 +7772,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7859,9 +7793,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7883,9 +7814,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.service.ts
+++ b/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.service.ts
@@ -187,6 +187,21 @@ export class PluginsSettingsUiService {
   async buildIndexHtml(pluginUi: HomebridgePluginUiMetadata, origin?: string) {
     const body = await this.getIndexHtmlBody(pluginUi)
 
+    // Re-sanitize the origin: only accept a validated URL origin (scheme + host
+    // + port) so that untrusted input cannot inject HTML attributes or
+    // javascript: URLs into the <script src>.
+    let safeOrigin = ''
+    if (origin) {
+      try {
+        const parsed = new URL(origin)
+        if ((parsed.protocol === 'http:' || parsed.protocol === 'https:') && parsed.origin === origin) {
+          safeOrigin = parsed.origin
+        }
+      } catch {
+        // leave safeOrigin as ''
+      }
+    }
+
     return `
       <!doctype html>
       <html>
@@ -200,7 +215,7 @@ export class PluginsSettingsUiService {
             serverEnv: ${JSON.stringify(this.configService.uiSettings(true)).replace(/</g, '\\u003c')},
           };
           </script>
-          <script src="${origin || ''}/assets/plugin-ui-utils/ui.js?v=${this.configService.package.version}"></script>
+          <script src="${safeOrigin}/assets/plugin-ui-utils/ui.js?v=${this.configService.package.version}"></script>
           <script>
             window.addEventListener('load', () => {
               window.parent.postMessage({action: 'loaded'}, '*');

--- a/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.service.ts
+++ b/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.service.ts
@@ -63,42 +63,42 @@ export class PluginsSettingsUiService {
       }
 
       // For non-HTML assets the CSP header is irrelevant to the browser, but
-      // setting an empty value prevents any stale header from leaking through.
+      // setting an empty value is a belt-and-suspenders measure that prevents
+      // any stale header from leaking through.
       reply.header('Content-Security-Policy', '')
 
       if (assetPath === 'index.html') {
-        // In production the primary UI and plugin UI are same-origin, so the
-        // request-supplied origin is ignored.
-        //
-        // In Angular development mode the primary UI runs on :4200 while
-        // Config UI X runs on :8581. Angular supplies its origin so the
-        // generated plugin UI can load assets from the Angular dev server.
-        //
-        // The server independently requires UIX_DEVELOPMENT=1 before it will
-        // consider the request-supplied origin. The origin remains untrusted
-        // and must pass resolveUiOrigin() before it is used.
+        // Resolved once here so the same value is used in both the CSP header
+        // and the HTML body — preventing any mismatch between the two. Empty in
+        // every normal case, which leaves the policy as plain 'self'.
+        // The cross-origin asset path is only needed when Angular's development
+        // server and the API run on different ports. Ignore caller-supplied
+        // origins entirely in production.
         const uiOrigin = process.env.UIX_DEVELOPMENT === '1'
           ? this.resolveUiOrigin(origin, reply.request?.headers?.host)
           : ''
-
-        const cspOrigin = uiOrigin ? ` ${uiOrigin}` : ''
-
+        const devOrigin = uiOrigin ? ` ${uiOrigin}` : ''
+        // Scope the CSP to this server.  'unsafe-inline' is required because the
+        // generated index.html contains two inline <script> blocks.
+        // 'unsafe-eval' is required because plugin custom UIs ran without any
+        // CSP before v5.24.1 and commonly use frameworks that evaluate
+        // expressions at runtime (e.g. Alpine.js, Vue) — see #2873.
+        // frame-ancestors restricts embedding to same-origin frames only,
+        // preventing the plugin iframe from being embedded by third-party pages.
         const extraDomains = pluginUi.customUiCspDomains?.length
           ? ` ${pluginUi.customUiCspDomains.join(' ')}`
           : ''
-
         reply.header(
           'Content-Security-Policy',
-          `default-src 'self'; `
-          + `script-src 'self' 'unsafe-inline' 'unsafe-eval'${cspOrigin}${extraDomains}; `
-          + `style-src 'self' 'unsafe-inline'${cspOrigin}; `
+          `default-src 'self'${devOrigin}; `
+          + `script-src 'self' 'unsafe-inline' 'unsafe-eval'${devOrigin}${extraDomains}; `
+          + `style-src 'self' 'unsafe-inline'${devOrigin}; `
           + `img-src * data:; `
           + `connect-src *; `
-          + `font-src 'self' data:${cspOrigin}; `
-          + `frame-ancestors 'self'${cspOrigin}; `
-          + `frame-src 'self'${cspOrigin}${extraDomains}`,
+          + `font-src 'self' data:; `
+          + `frame-ancestors 'self'${devOrigin}; `
+          + `frame-src 'self'${devOrigin}${extraDomains}`,
         )
-
         return reply
           .type('text/html')
           .send(await this.buildIndexHtml(pluginUi, uiOrigin))
@@ -145,17 +145,10 @@ export class PluginsSettingsUiService {
    */
   async serveAssetsFromDevServer(reply, pluginUi: HomebridgePluginUiMetadata, assetPath: string) {
     try {
-      const response = await firstValueFrom(
-        this.httpService.get(
-          `${pluginUi.devServer}/${assetPath}`,
-          { responseType: 'text' },
-        ),
-      )
-
+      const response = await firstValueFrom(this.httpService.get(`${pluginUi.devServer}/${assetPath}`, { responseType: 'text' }))
       for (const [key, value] of Object.entries(response.headers)) {
         reply.header(key, value)
       }
-
       reply.send(response.data)
     } catch {
       reply.code(404).send('Not Found')
@@ -168,14 +161,7 @@ export class PluginsSettingsUiService {
   async getIndexHtmlBody(pluginUi: HomebridgePluginUiMetadata) {
     if (pluginUi.devServer) {
       // Dev server is only enabled for private plugins
-      return (
-        await firstValueFrom(
-          this.httpService.get(
-            pluginUi.devServer,
-            { responseType: 'text' },
-          ),
-        )
-      ).data
+      return (await firstValueFrom(this.httpService.get(pluginUi.devServer, { responseType: 'text' }))).data
     } else {
       return await readFile(join(pluginUi.publicPath, 'index.html'), 'utf8')
     }
@@ -186,21 +172,10 @@ export class PluginsSettingsUiService {
    */
   async buildIndexHtml(pluginUi: HomebridgePluginUiMetadata, origin?: string) {
     const body = await this.getIndexHtmlBody(pluginUi)
-
-    // Re-sanitize the origin: only accept a validated URL origin (scheme + host
-    // + port) so that untrusted input cannot inject HTML attributes or
-    // javascript: URLs into the <script src>.
-    let safeOrigin = ''
-    if (origin) {
-      try {
-        const parsed = new URL(origin)
-        if ((parsed.protocol === 'http:' || parsed.protocol === 'https:') && parsed.origin === origin) {
-          safeOrigin = parsed.origin
-        }
-      } catch {
-        // leave safeOrigin as ''
-      }
-    }
+    // Checked again here rather than trusting the caller. serveCustomUiAsset
+    // already resolves the origin against the request host, but this method is
+    // reachable on its own, and the attribute below is the sink that mattered.
+    const safeOrigin = this.assertBareDevOrigin(origin)
 
     return `
       <!doctype html>
@@ -230,47 +205,70 @@ export class PluginsSettingsUiService {
   }
 
   /**
-   * Validate and resolve the Angular development server origin.
+   * Work out where `plugin-ui-utils/ui.js` should be loaded from.
    *
-   * This method is only called when UIX_DEVELOPMENT=1. The origin comes
-   * from the request URL and is therefore still treated as untrusted.
+   * Returns an empty string in every normal case, so the script tag below is
+   * written as a relative path and can only ever point back at this server.
    *
-   * The origin must:
-   * - use HTTP or HTTPS;
-   * - use a known development-server port;
-   * - use the same hostname as the Config UI X request;
-   * - contain only the scheme, hostname and port.
+   * The one exception is the Angular dev server: during `npm run dev` the UI is
+   * served from port 4200 while the API answers on 8581, so a relative path
+   * would look for the asset on the API and not find it. That case is allowed
+   * only when the supplied origin is on the *same host* the request arrived on
+   * and on a dev-server port - so a developer's own machine still works, and no
+   * caller can nominate a host of their choosing.
    *
-   * Any invalid value resolves to an empty string, causing the generated
-   * plugin UI to fall back to same-origin behaviour.
+   * This used to be a `sanitizeOrigin()` that checked the scheme and nothing
+   * else, which meant any `http(s)` host passed. That host was written into the
+   * CSP and into the `<script src>` of a page on the UI's own origin, so a
+   * crafted link ran the attacker's JavaScript with full UI authority and could
+   * read the session token out of localStorage. Reported privately, 2026-08-08.
    */
+  /**
+   * Accept a value only if it is exactly a bare origin - scheme and host, no
+   * path, query, fragment or credentials - on a dev-server port. Anything else
+   * becomes an empty string, which makes the script tag relative.
+   *
+   * Comparing against `url.origin` is what rejects a breakout attempt: a value
+   * carrying a quote or a closing tag never round-trips back to itself.
+   */
+  private assertBareDevOrigin(origin: string | undefined): string {
+    if (!origin) {
+      return ''
+    }
+    try {
+      const url = new URL(origin)
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return ''
+      }
+      if (!DEV_SERVER_PORTS.has(url.port)) {
+        return ''
+      }
+      return url.origin === origin ? url.origin : ''
+    } catch {
+      return ''
+    }
+  }
+
   private resolveUiOrigin(origin: string | undefined, requestHost: string | undefined): string {
     if (!origin) {
       return ''
     }
-
     try {
       const url = new URL(origin)
-
       if (url.protocol !== 'http:' && url.protocol !== 'https:') {
         return ''
       }
-
       if (!DEV_SERVER_PORTS.has(url.port)) {
         return ''
       }
-
-      // The API request arrives on :8581 while the Angular dev server runs
-      // on a different port, so compare only the hostname.
+      // `requestHost` still carries the port the API is listening on, which is
+      // not the port the dev server uses, so only the hostname is compared.
       const requestHostname = requestHost?.split(':')[0]
-
       if (!requestHostname || url.hostname !== requestHostname) {
         return ''
       }
-
-      // Only accept a bare origin. This rejects paths, queries, fragments,
-      // credentials and any other value that does not round-trip to url.origin.
-      return url.origin === origin ? url.origin : ''
+      // Only protocol + host, stripping any path, query or fragment
+      return url.origin
     } catch {
       return ''
     }
@@ -281,15 +279,8 @@ export class PluginsSettingsUiService {
    * expects: it settles the pending promise held against this request id by rejecting it.
    */
   private rejectRequest(pluginName: string, client: EventEmitter, requestId: string) {
-    client.emit('response', {
-      requestId,
-      success: false,
-      data: { message: CUSTOM_UI_UNAVAILABLE },
-    })
-
-    this.loggerService.debug(
-      `[${pluginName}] custom UI request ${requestId} rejected (no server-side handler available).`,
-    )
+    client.emit('response', { requestId, success: false, data: { message: CUSTOM_UI_UNAVAILABLE } })
+    this.loggerService.debug(`[${pluginName}] custom UI request ${requestId} rejected (no server-side handler available).`)
   }
 
   /**
@@ -325,16 +316,12 @@ export class PluginsSettingsUiService {
     // (or both, if the first fails) could land on an unrelated process.
     // The single-shot flag plus a `child.killed` check prevents that.
     let cleaned = false
-
     const cleanup = () => {
       if (cleaned) {
         return
       }
-
       cleaned = true
-      this.loggerService.debug(
-        `[${pluginName}] custom UI closing (terminating child process)...`,
-      )
+      this.loggerService.debug(`[${pluginName}] custom UI closing (terminating child process)...`)
 
       // On a disconnect the socket is gone and these emits are harmless; on a modal close or a
       // supersede the socket survives and the iframe gets its answers.
@@ -346,25 +333,20 @@ export class PluginsSettingsUiService {
       child?.removeAllListeners('message')
 
       const childPid = child?.pid
-
       if (child?.connected) {
         child.disconnect()
       }
-
       if (child) {
         setTimeout(() => {
           if (child.killed || !childPid) {
             return
           }
-
           try {
             process.kill(childPid, 'SIGTERM')
           } catch (e: any) {
             // ESRCH is fine — the child already exited. Surface anything else.
             if (e?.code !== 'ESRCH') {
-              this.loggerService.warn(
-                `[${pluginName}] failed to SIGTERM child pid ${childPid}: ${e.message}`,
-              )
+              this.loggerService.warn(`[${pluginName}] failed to SIGTERM child pid ${childPid}: ${e.message}`)
             }
           }
         }, 5000)
@@ -386,7 +368,6 @@ export class PluginsSettingsUiService {
         if (request?.requestId) {
           outstanding.add(request.requestId)
         }
-
         child.send(request)
       } else if (request?.requestId) {
         this.rejectRequest(pluginName, client, request.requestId)
@@ -399,7 +380,7 @@ export class PluginsSettingsUiService {
     const pluginUi: HomebridgePluginUiMetadata = (this.pluginUiMetadataCache.get(pluginName) as any)
       || (await this.getPluginUiMetadata(pluginName))
 
-    // Check the plugin has a server side script.
+    // check the plugin has a server side script
     const hasServerScript = await pathExists(resolve(pluginUi.serverPath))
 
     // An invocation superseded, or a socket closed, while the lookups above were in flight must
@@ -413,13 +394,13 @@ export class PluginsSettingsUiService {
       return
     }
 
-    // Pass all env vars to server side script.
+    // Pass all env vars to server side script
     const childEnv = { ...process.env }
     childEnv.HOMEBRIDGE_STORAGE_PATH = this.configService.storagePath
     childEnv.HOMEBRIDGE_CONFIG_PATH = this.configService.configPath
     childEnv.HOMEBRIDGE_UI_VERSION = this.configService.package.version
 
-    // Launch the server side script.
+    // Launch the server side script
     child = fork(pluginUi.serverPath, [], {
       silent: true,
       env: childEnv,
@@ -434,30 +415,21 @@ export class PluginsSettingsUiService {
     })
 
     child.on('exit', () => {
-      this.loggerService.debug(
-        `[${pluginName}] custom UI closed (child process ended).`,
-      )
+      this.loggerService.debug(`[${pluginName}] custom UI closed (child process ended).`)
 
       // A crash, or a kill from the cleanup path, can take the child down with requests still in
       // flight. Nothing will ever answer those, so settle them here.
       settleOutstanding()
     })
 
-    child.addListener(
-      'message',
-      (response: { action: string, payload: any }) => {
-        if (typeof response === 'object' && response.action) {
-          if (response.action === 'response' && response.payload?.requestId) {
-            outstanding.delete(response.payload.requestId)
-          }
-
-          response.action = response.action === 'error'
-            ? 'server_error'
-            : response.action
-
-          client.emit(response.action, response.payload)
+    child.addListener('message', (response: { action: string, payload: any }) => {
+      if (typeof response === 'object' && response.action) {
+        if (response.action === 'response' && response.payload?.requestId) {
+          outstanding.delete(response.payload.requestId)
         }
-      },
-    )
+        response.action = response.action === 'error' ? 'server_error' : response.action
+        client.emit(response.action, response.payload)
+      }
+    })
   }
 }

--- a/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.service.ts
+++ b/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.service.ts
@@ -63,37 +63,42 @@ export class PluginsSettingsUiService {
       }
 
       // For non-HTML assets the CSP header is irrelevant to the browser, but
-      // setting an empty value is a belt-and-suspenders measure that prevents
-      // any stale header from leaking through.
+      // setting an empty value prevents any stale header from leaking through.
       reply.header('Content-Security-Policy', '')
 
       if (assetPath === 'index.html') {
-        // Resolved once here so the same value is used in both the CSP header
-        // and the HTML body — preventing any mismatch between the two. Empty in
-        // every normal case, which leaves the policy as plain 'self'.
-        const uiOrigin = this.resolveUiOrigin(origin, reply.request?.headers?.host)
-        const devOrigin = uiOrigin ? ` ${uiOrigin}` : ''
-        // Scope the CSP to this server.  'unsafe-inline' is required because the
-        // generated index.html contains two inline <script> blocks.
-        // 'unsafe-eval' is required because plugin custom UIs ran without any
-        // CSP before v5.24.1 and commonly use frameworks that evaluate
-        // expressions at runtime (e.g. Alpine.js, Vue) — see #2873.
-        // frame-ancestors restricts embedding to same-origin frames only,
-        // preventing the plugin iframe from being embedded by third-party pages.
+        // In production the primary UI and plugin UI are same-origin, so the
+        // request-supplied origin is ignored.
+        //
+        // In Angular development mode the primary UI runs on :4200 while
+        // Config UI X runs on :8581. Angular supplies its origin so the
+        // generated plugin UI can load assets from the Angular dev server.
+        //
+        // The server independently requires UIX_DEVELOPMENT=1 before it will
+        // consider the request-supplied origin. The origin remains untrusted
+        // and must pass resolveUiOrigin() before it is used.
+        const uiOrigin = process.env.UIX_DEVELOPMENT === '1'
+          ? this.resolveUiOrigin(origin, reply.request?.headers?.host)
+          : ''
+
+        const cspOrigin = uiOrigin ? ` ${uiOrigin}` : ''
+
         const extraDomains = pluginUi.customUiCspDomains?.length
           ? ` ${pluginUi.customUiCspDomains.join(' ')}`
           : ''
+
         reply.header(
           'Content-Security-Policy',
-          `default-src 'self'${devOrigin}; `
-          + `script-src 'self' 'unsafe-inline' 'unsafe-eval'${devOrigin}${extraDomains}; `
-          + `style-src 'self' 'unsafe-inline'${devOrigin}; `
+          `default-src 'self'; `
+          + `script-src 'self' 'unsafe-inline' 'unsafe-eval'${cspOrigin}${extraDomains}; `
+          + `style-src 'self' 'unsafe-inline'${cspOrigin}; `
           + `img-src * data:; `
           + `connect-src *; `
-          + `font-src 'self' data:; `
-          + `frame-ancestors 'self'${devOrigin}; `
-          + `frame-src 'self'${devOrigin}${extraDomains}`,
+          + `font-src 'self' data:${cspOrigin}; `
+          + `frame-ancestors 'self'${cspOrigin}; `
+          + `frame-src 'self'${cspOrigin}${extraDomains}`,
         )
+
         return reply
           .type('text/html')
           .send(await this.buildIndexHtml(pluginUi, uiOrigin))
@@ -140,10 +145,17 @@ export class PluginsSettingsUiService {
    */
   async serveAssetsFromDevServer(reply, pluginUi: HomebridgePluginUiMetadata, assetPath: string) {
     try {
-      const response = await firstValueFrom(this.httpService.get(`${pluginUi.devServer}/${assetPath}`, { responseType: 'text' }))
+      const response = await firstValueFrom(
+        this.httpService.get(
+          `${pluginUi.devServer}/${assetPath}`,
+          { responseType: 'text' },
+        ),
+      )
+
       for (const [key, value] of Object.entries(response.headers)) {
         reply.header(key, value)
       }
+
       reply.send(response.data)
     } catch {
       reply.code(404).send('Not Found')
@@ -156,7 +168,14 @@ export class PluginsSettingsUiService {
   async getIndexHtmlBody(pluginUi: HomebridgePluginUiMetadata) {
     if (pluginUi.devServer) {
       // Dev server is only enabled for private plugins
-      return (await firstValueFrom(this.httpService.get(pluginUi.devServer, { responseType: 'text' }))).data
+      return (
+        await firstValueFrom(
+          this.httpService.get(
+            pluginUi.devServer,
+            { responseType: 'text' },
+          ),
+        )
+      ).data
     } else {
       return await readFile(join(pluginUi.publicPath, 'index.html'), 'utf8')
     }
@@ -167,10 +186,6 @@ export class PluginsSettingsUiService {
    */
   async buildIndexHtml(pluginUi: HomebridgePluginUiMetadata, origin?: string) {
     const body = await this.getIndexHtmlBody(pluginUi)
-    // Checked again here rather than trusting the caller. serveCustomUiAsset
-    // already resolves the origin against the request host, but this method is
-    // reachable on its own, and the attribute below is the sink that mattered.
-    const safeOrigin = this.assertBareDevOrigin(origin)
 
     return `
       <!doctype html>
@@ -185,7 +200,7 @@ export class PluginsSettingsUiService {
             serverEnv: ${JSON.stringify(this.configService.uiSettings(true)).replace(/</g, '\\u003c')},
           };
           </script>
-          <script src="${safeOrigin}/assets/plugin-ui-utils/ui.js?v=${this.configService.package.version}"></script>
+          <script src="${origin || ''}/assets/plugin-ui-utils/ui.js?v=${this.configService.package.version}"></script>
           <script>
             window.addEventListener('load', () => {
               window.parent.postMessage({action: 'loaded'}, '*');
@@ -200,70 +215,47 @@ export class PluginsSettingsUiService {
   }
 
   /**
-   * Work out where `plugin-ui-utils/ui.js` should be loaded from.
+   * Validate and resolve the Angular development server origin.
    *
-   * Returns an empty string in every normal case, so the script tag below is
-   * written as a relative path and can only ever point back at this server.
+   * This method is only called when UIX_DEVELOPMENT=1. The origin comes
+   * from the request URL and is therefore still treated as untrusted.
    *
-   * The one exception is the Angular dev server: during `npm run dev` the UI is
-   * served from port 4200 while the API answers on 8581, so a relative path
-   * would look for the asset on the API and not find it. That case is allowed
-   * only when the supplied origin is on the *same host* the request arrived on
-   * and on a dev-server port - so a developer's own machine still works, and no
-   * caller can nominate a host of their choosing.
+   * The origin must:
+   * - use HTTP or HTTPS;
+   * - use a known development-server port;
+   * - use the same hostname as the Config UI X request;
+   * - contain only the scheme, hostname and port.
    *
-   * This used to be a `sanitizeOrigin()` that checked the scheme and nothing
-   * else, which meant any `http(s)` host passed. That host was written into the
-   * CSP and into the `<script src>` of a page on the UI's own origin, so a
-   * crafted link ran the attacker's JavaScript with full UI authority and could
-   * read the session token out of localStorage. Reported privately, 2026-08-08.
+   * Any invalid value resolves to an empty string, causing the generated
+   * plugin UI to fall back to same-origin behaviour.
    */
-  /**
-   * Accept a value only if it is exactly a bare origin - scheme and host, no
-   * path, query, fragment or credentials - on a dev-server port. Anything else
-   * becomes an empty string, which makes the script tag relative.
-   *
-   * Comparing against `url.origin` is what rejects a breakout attempt: a value
-   * carrying a quote or a closing tag never round-trips back to itself.
-   */
-  private assertBareDevOrigin(origin: string | undefined): string {
-    if (!origin) {
-      return ''
-    }
-    try {
-      const url = new URL(origin)
-      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-        return ''
-      }
-      if (!DEV_SERVER_PORTS.has(url.port)) {
-        return ''
-      }
-      return url.origin === origin ? url.origin : ''
-    } catch {
-      return ''
-    }
-  }
-
   private resolveUiOrigin(origin: string | undefined, requestHost: string | undefined): string {
     if (!origin) {
       return ''
     }
+
     try {
       const url = new URL(origin)
+
       if (url.protocol !== 'http:' && url.protocol !== 'https:') {
         return ''
       }
+
       if (!DEV_SERVER_PORTS.has(url.port)) {
         return ''
       }
-      // `requestHost` still carries the port the API is listening on, which is
-      // not the port the dev server uses, so only the hostname is compared.
+
+      // The API request arrives on :8581 while the Angular dev server runs
+      // on a different port, so compare only the hostname.
       const requestHostname = requestHost?.split(':')[0]
+
       if (!requestHostname || url.hostname !== requestHostname) {
         return ''
       }
-      // Only protocol + host, stripping any path, query or fragment
-      return url.origin
+
+      // Only accept a bare origin. This rejects paths, queries, fragments,
+      // credentials and any other value that does not round-trip to url.origin.
+      return url.origin === origin ? url.origin : ''
     } catch {
       return ''
     }
@@ -274,8 +266,15 @@ export class PluginsSettingsUiService {
    * expects: it settles the pending promise held against this request id by rejecting it.
    */
   private rejectRequest(pluginName: string, client: EventEmitter, requestId: string) {
-    client.emit('response', { requestId, success: false, data: { message: CUSTOM_UI_UNAVAILABLE } })
-    this.loggerService.debug(`[${pluginName}] custom UI request ${requestId} rejected (no server-side handler available).`)
+    client.emit('response', {
+      requestId,
+      success: false,
+      data: { message: CUSTOM_UI_UNAVAILABLE },
+    })
+
+    this.loggerService.debug(
+      `[${pluginName}] custom UI request ${requestId} rejected (no server-side handler available).`,
+    )
   }
 
   /**
@@ -311,12 +310,16 @@ export class PluginsSettingsUiService {
     // (or both, if the first fails) could land on an unrelated process.
     // The single-shot flag plus a `child.killed` check prevents that.
     let cleaned = false
+
     const cleanup = () => {
       if (cleaned) {
         return
       }
+
       cleaned = true
-      this.loggerService.debug(`[${pluginName}] custom UI closing (terminating child process)...`)
+      this.loggerService.debug(
+        `[${pluginName}] custom UI closing (terminating child process)...`,
+      )
 
       // On a disconnect the socket is gone and these emits are harmless; on a modal close or a
       // supersede the socket survives and the iframe gets its answers.
@@ -328,20 +331,25 @@ export class PluginsSettingsUiService {
       child?.removeAllListeners('message')
 
       const childPid = child?.pid
+
       if (child?.connected) {
         child.disconnect()
       }
+
       if (child) {
         setTimeout(() => {
           if (child.killed || !childPid) {
             return
           }
+
           try {
             process.kill(childPid, 'SIGTERM')
           } catch (e: any) {
             // ESRCH is fine — the child already exited. Surface anything else.
             if (e?.code !== 'ESRCH') {
-              this.loggerService.warn(`[${pluginName}] failed to SIGTERM child pid ${childPid}: ${e.message}`)
+              this.loggerService.warn(
+                `[${pluginName}] failed to SIGTERM child pid ${childPid}: ${e.message}`,
+              )
             }
           }
         }, 5000)
@@ -363,6 +371,7 @@ export class PluginsSettingsUiService {
         if (request?.requestId) {
           outstanding.add(request.requestId)
         }
+
         child.send(request)
       } else if (request?.requestId) {
         this.rejectRequest(pluginName, client, request.requestId)
@@ -375,7 +384,7 @@ export class PluginsSettingsUiService {
     const pluginUi: HomebridgePluginUiMetadata = (this.pluginUiMetadataCache.get(pluginName) as any)
       || (await this.getPluginUiMetadata(pluginName))
 
-    // check the plugin has a server side script
+    // Check the plugin has a server side script.
     const hasServerScript = await pathExists(resolve(pluginUi.serverPath))
 
     // An invocation superseded, or a socket closed, while the lookups above were in flight must
@@ -389,13 +398,13 @@ export class PluginsSettingsUiService {
       return
     }
 
-    // Pass all env vars to server side script
+    // Pass all env vars to server side script.
     const childEnv = { ...process.env }
     childEnv.HOMEBRIDGE_STORAGE_PATH = this.configService.storagePath
     childEnv.HOMEBRIDGE_CONFIG_PATH = this.configService.configPath
     childEnv.HOMEBRIDGE_UI_VERSION = this.configService.package.version
 
-    // Launch the server side script
+    // Launch the server side script.
     child = fork(pluginUi.serverPath, [], {
       silent: true,
       env: childEnv,
@@ -410,21 +419,30 @@ export class PluginsSettingsUiService {
     })
 
     child.on('exit', () => {
-      this.loggerService.debug(`[${pluginName}] custom UI closed (child process ended).`)
+      this.loggerService.debug(
+        `[${pluginName}] custom UI closed (child process ended).`,
+      )
 
       // A crash, or a kill from the cleanup path, can take the child down with requests still in
       // flight. Nothing will ever answer those, so settle them here.
       settleOutstanding()
     })
 
-    child.addListener('message', (response: { action: string, payload: any }) => {
-      if (typeof response === 'object' && response.action) {
-        if (response.action === 'response' && response.payload?.requestId) {
-          outstanding.delete(response.payload.requestId)
+    child.addListener(
+      'message',
+      (response: { action: string, payload: any }) => {
+        if (typeof response === 'object' && response.action) {
+          if (response.action === 'response' && response.payload?.requestId) {
+            outstanding.delete(response.payload.requestId)
+          }
+
+          response.action = response.action === 'error'
+            ? 'server_error'
+            : response.action
+
+          client.emit(response.action, response.payload)
         }
-        response.action = response.action === 'error' ? 'server_error' : response.action
-        client.emit(response.action, response.payload)
-      }
-    })
+      },
+    )
   }
 }

--- a/test/e2e/plugin-settings-ui.e2e-spec.ts
+++ b/test/e2e/plugin-settings-ui.e2e-spec.ts
@@ -12,7 +12,7 @@ import { Test } from '@nestjs/testing'
 import { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { copy, ensureDir, remove, writeFile } from 'fs-extra'
 import { of } from 'rxjs'
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AuthModule } from '../../src/core/auth/auth.module.js'
 import { PluginsSettingsUiModule } from '../../src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.module.js'
@@ -84,286 +84,350 @@ describe('PluginsSettingsUiController (e2e)', () => {
     vi.resetAllMocks()
   })
 
-  it('GET /plugins/settings-ui/:plugin-name/ (no cookie → 401)', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      path: '/plugins/settings-ui/homebridge-mock-plugin/',
-    })
+  describe('GET /plugins/settings-ui/:plugin-name/*', () => {
+    describe('authentication', () => {
+      it('rejects a request without an hb-session cookie', async () => {
+        const res = await app.inject({
+          method: 'GET',
+          path: '/plugins/settings-ui/homebridge-mock-plugin/',
+        })
 
-    expect(res.statusCode).toBe(401)
-  })
-
-  it('Bearer-only session mints hb-session via refresh then loads settings-ui (#2893)', async () => {
-    // Mid-session upgrade path: valid Bearer token in localStorage, but no
-    // hb-session cookie (never set on ≤5.24.x sessions). Bootstrap calls
-    // POST /auth/refresh; the Set-Cookie must be enough for CookieAuthGuard.
-    const loginRes = await app.inject({
-      method: 'POST',
-      path: '/auth/login',
-      payload: { username: 'admin', password: 'admin' },
-    })
-    const { access_token } = JSON.parse(loginRes.body)
-
-    const denied = await app.inject({
-      method: 'GET',
-      path: '/plugins/settings-ui/homebridge-mock-plugin/index.html',
-    })
-    expect(denied.statusCode).toBe(401)
-
-    const refreshRes = await app.inject({
-      method: 'POST',
-      path: '/auth/refresh',
-      headers: { authorization: `bearer ${access_token}` },
-    })
-    expect(refreshRes.statusCode).toBe(201)
-
-    const setCookie = refreshRes.headers['set-cookie']
-    const cookieHeaders = Array.isArray(setCookie) ? setCookie : setCookie ? [setCookie] : []
-    const hbSessionHeader = cookieHeaders.find(c => c.startsWith('hb-session='))
-    expect(hbSessionHeader).toBeTruthy()
-    const cookiePair = hbSessionHeader!.split(';')[0]
-
-    const allowed = await app.inject({
-      method: 'GET',
-      path: '/plugins/settings-ui/homebridge-mock-plugin/index.html',
-      headers: { cookie: cookiePair },
-    })
-    expect(allowed.statusCode).toBe(200)
-    expect(allowed.body).toContain('Hello World')
-  })
-
-  it('GET /plugins/settings-ui/:plugin-name/ (invalid cookie → 401)', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      path: '/plugins/settings-ui/homebridge-mock-plugin/',
-      headers: { cookie: 'hb-session=not-a-valid-jwt' },
-    })
-
-    expect(res.statusCode).toBe(401)
-  })
-
-  it('GET /plugins/settings-ui/:plugin-name/', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      path: '/plugins/settings-ui/homebridge-mock-plugin/',
-      headers: { cookie: sessionCookie },
-    })
-
-    expect(res.statusCode).toBe(200)
-    expect(res.body).toContain('Hello World')
-    expect(res.body).toContain('homebridge-mock-plugin')
-  })
-
-  it('GET /plugins/settings-ui/:plugin-name/index.html', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      path: '/plugins/settings-ui/homebridge-mock-plugin/index.html',
-      headers: { cookie: sessionCookie },
-    })
-
-    expect(res.statusCode).toBe(200)
-    expect(res.body).toContain('Hello World')
-    expect(res.body).toContain('homebridge-mock-plugin')
-    // A non-empty CSP must be present on the index.html response
-    const csp = res.headers['content-security-policy'] as string
-    expect(csp).toBeTruthy()
-    expect(csp).toContain('script-src')
-    // Custom UIs ran without any CSP before v5.24.1 — frameworks that
-    // evaluate expressions at runtime (e.g. Alpine.js, Vue) need this (#2873)
-    expect(csp).toContain('\'unsafe-eval\'')
-    expect(csp).toContain('frame-ancestors')
-  })
-
-  it('GET /plugins/settings-ui/:plugin-name/index.html ignores customUiCspDomains entries longer than 256 bytes', async () => {
-    const { readJson, writeJson } = await import('fs-extra')
-
-    const baseSchemaPath = resolve(pluginsPath, 'homebridge-mock-plugin', 'config.schema.json')
-    const baseSchema = await readJson(baseSchemaPath)
-    const maxLengthDomain = `https://${'a'.repeat(244)}.com`
-    const overLengthDomain = `https://${'b'.repeat(245)}.com`
-    const pluginsService = app.get(PluginsService)
-    const loggerErrorSpy = vi.spyOn((pluginsService as any).logger, 'error').mockImplementation(() => undefined)
-
-    try {
-      await writeJson(baseSchemaPath, {
-        ...baseSchema,
-        customUiCspDomains: [maxLengthDomain, overLengthDomain],
-      })
-      ;(app.get(PluginsSettingsUiService) as any).pluginUiMetadataCache.del('homebridge-mock-plugin')
-      ;(app.get(PluginsSettingsUiService) as any).pluginUiLastVersionCache.del('homebridge-mock-plugin')
-
-      const res = await app.inject({
-        method: 'GET',
-        path: '/plugins/settings-ui/homebridge-mock-plugin/index.html',
-        headers: { cookie: sessionCookie },
+        expect(res.statusCode).toBe(401)
       })
 
-      expect(res.statusCode).toBe(200)
-      const csp = res.headers['content-security-policy'] as string
-      expect(csp).toContain(maxLengthDomain)
-      expect(csp).not.toContain(overLengthDomain)
-      expect(loggerErrorSpy).toHaveBeenCalledWith('Ignoring customUiCspDomains entry longer than 256 bytes.')
-    } finally {
-      await writeJson(baseSchemaPath, baseSchema)
-      ;(app.get(PluginsSettingsUiService) as any).pluginUiMetadataCache.del('homebridge-mock-plugin')
-      ;(app.get(PluginsSettingsUiService) as any).pluginUiLastVersionCache.del('homebridge-mock-plugin')
-    }
-  })
+      it('rejects a valid bearer token without an hb-session cookie', async () => {
+        const loginRes = await app.inject({
+          method: 'POST',
+          path: '/auth/login',
+          payload: { username: 'admin', password: 'admin' },
+        })
+        const { access_token } = JSON.parse(loginRes.body)
 
-  it('GET /plugins/settings-ui/:plugin-name/index.html (foreign origin → ignored)', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent('http://example.com')}`,
-      headers: { cookie: sessionCookie },
-    })
+        const res = await app.inject({
+          method: 'GET',
+          path: '/plugins/settings-ui/homebridge-mock-plugin/index.html',
+          headers: { authorization: `Bearer ${access_token}` },
+        })
 
-    expect(res.statusCode).toBe(200)
-    // A caller-supplied host must never reach the script tag or the policy.
-    // This used to be reflected, which is what made the page loadable with an
-    // attacker's script on the UI's own origin.
-    expect(res.body).not.toContain('http://example.com')
-    expect(res.headers['content-security-policy']).not.toContain('http://example.com')
-    expect(res.body).toContain('src="/assets/plugin-ui-utils/ui.js')
-  })
-
-  it('GET /plugins/settings-ui/:plugin-name/index.html (foreign origin on a dev port → ignored)', async () => {
-    // Being on a dev-server port is not enough on its own - the host has to
-    // match the host the request arrived on
-    const res = await app.inject({
-      method: 'GET',
-      path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent('http://attacker.example.com:4200')}`,
-      headers: { cookie: sessionCookie, host: 'localhost:8581' },
-    })
-
-    expect(res.statusCode).toBe(200)
-    expect(res.body).not.toContain('attacker.example.com')
-    expect(res.headers['content-security-policy']).not.toContain('attacker.example.com')
-    expect(res.body).toContain('src="/assets/plugin-ui-utils/ui.js')
-  })
-
-  it('GET /plugins/settings-ui/:plugin-name/index.html (matching dev server origin → allowed)', async () => {
-    // `npm run dev` serves the UI on 4200 while the API answers on 8581, so a
-    // relative path would not find the asset. Same host, dev port, so allowed.
-    const previousDevelopment = process.env.UIX_DEVELOPMENT
-    try {
-      process.env.UIX_DEVELOPMENT = '1'
-      const res = await app.inject({
-        method: 'GET',
-        path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent('http://localhost:4200')}`,
-        headers: { cookie: sessionCookie, host: 'localhost:8581' },
+        expect(res.statusCode).toBe(401)
       })
 
-      expect(res.statusCode).toBe(200)
-      expect(res.body).toContain('http://localhost:4200/assets/plugin-ui-utils/ui.js')
-      expect(res.headers['content-security-policy']).toContain('http://localhost:4200')
-    } finally {
-      if (previousDevelopment === undefined) {
-        delete process.env.UIX_DEVELOPMENT
-      } else {
-        process.env.UIX_DEVELOPMENT = previousDevelopment
-      }
-    }
-  })
+      it('rejects an invalid bearer token without an hb-session cookie', async () => {
+        const res = await app.inject({
+          method: 'GET',
+          path: '/plugins/settings-ui/homebridge-mock-plugin/index.html',
+          headers: { authorization: 'Bearer not-a-valid-jwt' },
+        })
 
-  it('GET /plugins/settings-ui/:plugin-name/index.html (matching dev server origin in production → ignored)', async () => {
-    const previousDevelopment = process.env.UIX_DEVELOPMENT
-    try {
-      delete process.env.UIX_DEVELOPMENT
-
-      const res = await app.inject({
-        method: 'GET',
-        path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent('http://localhost:4200')}`,
-        headers: { cookie: sessionCookie, host: 'localhost:8581' },
+        expect(res.statusCode).toBe(401)
       })
 
-      expect(res.statusCode).toBe(200)
-      expect(res.body).not.toContain('http://localhost:4200')
-      expect(res.headers['content-security-policy']).not.toContain('http://localhost:4200')
-      expect(res.body).toContain('src="/assets/plugin-ui-utils/ui.js')
-    } finally {
-      if (previousDevelopment !== undefined) {
-        process.env.UIX_DEVELOPMENT = previousDevelopment
-      }
-    }
-  })
+      it('mints hb-session via bearer refresh then loads settings-ui (#2893)', async () => {
+        // Mid-session upgrade path: valid Bearer token in localStorage, but no
+        // hb-session cookie (never set on ≤5.24.x sessions). Bootstrap calls
+        // POST /auth/refresh; the Set-Cookie must be enough for CookieAuthGuard.
+        const loginRes = await app.inject({
+          method: 'POST',
+          path: '/auth/login',
+          payload: { username: 'admin', password: 'admin' },
+        })
+        const { access_token } = JSON.parse(loginRes.body)
 
-  it('GET /plugins/settings-ui/:plugin-name/index.html (XSS via origin → rejected)', async () => {
-    const xssOrigin = encodeURIComponent('"></' + 'script><script>alert(document.domain)</script>')
-    const res = await app.inject({
-      method: 'GET',
-      path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${xssOrigin}`,
-      headers: { cookie: sessionCookie },
+        const denied = await app.inject({
+          method: 'GET',
+          path: '/plugins/settings-ui/homebridge-mock-plugin/index.html',
+        })
+        expect(denied.statusCode).toBe(401)
+
+        const refreshRes = await app.inject({
+          method: 'POST',
+          path: '/auth/refresh',
+          headers: { authorization: `bearer ${access_token}` },
+        })
+        expect(refreshRes.statusCode).toBe(201)
+
+        const setCookie = refreshRes.headers['set-cookie']
+        const cookieHeaders = Array.isArray(setCookie) ? setCookie : setCookie ? [setCookie] : []
+        const hbSessionHeader = cookieHeaders.find(c => c.startsWith('hb-session='))
+        expect(hbSessionHeader).toBeTruthy()
+        const cookiePair = hbSessionHeader!.split(';')[0]
+
+        const allowed = await app.inject({
+          method: 'GET',
+          path: '/plugins/settings-ui/homebridge-mock-plugin/index.html',
+          headers: { cookie: cookiePair },
+        })
+        expect(allowed.statusCode).toBe(200)
+        expect(allowed.body).toContain('Hello World')
+      })
+
+      it('rejects an invalid hb-session cookie', async () => {
+        const res = await app.inject({
+          method: 'GET',
+          path: '/plugins/settings-ui/homebridge-mock-plugin/',
+          headers: { cookie: 'hb-session=not-a-valid-jwt' },
+        })
+
+        expect(res.statusCode).toBe(401)
+      })
+
+      it('accepts a valid hb-session cookie', async () => {
+        const res = await app.inject({
+          method: 'GET',
+          path: '/plugins/settings-ui/homebridge-mock-plugin/',
+          headers: { cookie: sessionCookie },
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(res.body).toContain('Hello World')
+        expect(res.body).toContain('homebridge-mock-plugin')
+      })
     })
 
-    expect(res.statusCode).toBe(200)
-    // The malicious origin must not appear verbatim in the response
-    expect(res.body).not.toContain('alert(document.domain)')
-    // Falls back to a relative path, which cannot carry a host at all
-    expect(res.body).toContain('src="/assets/plugin-ui-utils/ui.js')
-  })
+    describe('index HTML and CSP', () => {
+      it('serves the plugin index with its content security policy', async () => {
+        const res = await app.inject({
+          method: 'GET',
+          path: '/plugins/settings-ui/homebridge-mock-plugin/index.html',
+          headers: { cookie: sessionCookie },
+        })
 
-  it('GET /plugins/settings-ui/:plugin-name/index.html (non-http origin → rejected)', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent('javascript:alert(1)')}`,
-      headers: { cookie: sessionCookie },
+        expect(res.statusCode).toBe(200)
+        expect(res.body).toContain('Hello World')
+        expect(res.body).toContain('homebridge-mock-plugin')
+        // A non-empty CSP must be present on the index.html response
+        const csp = res.headers['content-security-policy'] as string
+        expect(csp).toBeTruthy()
+        expect(csp).toContain('script-src')
+        // Custom UIs ran without any CSP before v5.24.1 — frameworks that
+        // evaluate expressions at runtime (e.g. Alpine.js, Vue) need this (#2873)
+        expect(csp).toContain('\'unsafe-eval\'')
+        expect(csp).toContain('frame-ancestors')
+      })
+
+      it('ignores customUiCspDomains entries longer than 256 bytes', async () => {
+        const { readJson, writeJson } = await import('fs-extra')
+
+        const baseSchemaPath = resolve(pluginsPath, 'homebridge-mock-plugin', 'config.schema.json')
+        const baseSchema = await readJson(baseSchemaPath)
+        const maxLengthDomain = `https://${'a'.repeat(244)}.com`
+        const overLengthDomain = `https://${'b'.repeat(245)}.com`
+        const pluginsService = app.get(PluginsService)
+        const loggerErrorSpy = vi.spyOn((pluginsService as any).logger, 'error').mockImplementation(() => undefined)
+
+        try {
+          await writeJson(baseSchemaPath, {
+            ...baseSchema,
+            customUiCspDomains: [maxLengthDomain, overLengthDomain],
+          })
+          ;(app.get(PluginsSettingsUiService) as any).pluginUiMetadataCache.del('homebridge-mock-plugin')
+          ;(app.get(PluginsSettingsUiService) as any).pluginUiLastVersionCache.del('homebridge-mock-plugin')
+
+          const res = await app.inject({
+            method: 'GET',
+            path: '/plugins/settings-ui/homebridge-mock-plugin/index.html',
+            headers: { cookie: sessionCookie },
+          })
+
+          expect(res.statusCode).toBe(200)
+          const csp = res.headers['content-security-policy'] as string
+          expect(csp).toContain(maxLengthDomain)
+          expect(csp).not.toContain(overLengthDomain)
+          expect(loggerErrorSpy).toHaveBeenCalledWith('Ignoring customUiCspDomains entry longer than 256 bytes.')
+        } finally {
+          await writeJson(baseSchemaPath, baseSchema)
+          ;(app.get(PluginsSettingsUiService) as any).pluginUiMetadataCache.del('homebridge-mock-plugin')
+          ;(app.get(PluginsSettingsUiService) as any).pluginUiLastVersionCache.del('homebridge-mock-plugin')
+        }
+      })
     })
 
-    expect(res.statusCode).toBe(200)
-    expect(res.body).not.toContain('javascript:alert(1)')
-    expect(res.body).toContain('src="/assets/plugin-ui-utils/ui.js')
-  })
+    describe('origin handling', () => {
+      let previousDevelopment: string | undefined
 
-  it('GET /plugins/settings-ui/:plugin-name/index.html (no custom ui for plugin)', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      path: '/plugins/settings-ui/homebridge-mock-plugin-two/index.html',
-      headers: { cookie: sessionCookie },
+      beforeEach(() => {
+        previousDevelopment = process.env.UIX_DEVELOPMENT
+      })
+
+      afterEach(() => {
+        if (previousDevelopment === undefined) {
+          delete process.env.UIX_DEVELOPMENT
+        } else {
+          process.env.UIX_DEVELOPMENT = previousDevelopment
+        }
+      })
+
+      describe('in production', () => {
+        beforeEach(() => {
+          delete process.env.UIX_DEVELOPMENT
+        })
+
+        it.each([
+          {
+            description: 'a matching development-server origin',
+            origin: 'http://localhost:4200',
+          },
+          {
+            description: 'an attacker hostname on an allowed development port',
+            origin: 'http://attacker.example.com:4200',
+          },
+          {
+            description: 'a matching hostname on a non-development port',
+            origin: 'http://localhost:4444',
+          },
+          {
+            description: 'an origin containing an XSS payload',
+            origin: '"></' + 'script><script>alert(document.domain)</script>',
+          },
+          {
+            description: 'a non-http origin',
+            origin: 'javascript:alert(1)',
+          },
+        ])('ignores $description', async ({ origin }) => {
+          const res = await app.inject({
+            method: 'GET',
+            path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent(origin)}`,
+            headers: { cookie: sessionCookie, host: 'localhost:8581' },
+          })
+
+          expect(res.statusCode).toBe(200)
+          expect(res.body).not.toContain(origin)
+          expect(res.headers['content-security-policy']).not.toContain(origin)
+          expect(res.body).toContain('src="/assets/plugin-ui-utils/ui.js')
+        })
+      })
+
+      describe('in development', () => {
+        beforeEach(() => {
+          process.env.UIX_DEVELOPMENT = '1'
+        })
+
+        it('allows a matching development-server origin', async () => {
+        // `npm run dev` serves the UI on 4200 while the API answers on 8581, so a
+        // relative path would not find the asset. Same host, dev port, so allowed.
+          const origin = 'http://localhost:4200'
+          const res = await app.inject({
+            method: 'GET',
+            path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent(origin)}`,
+            headers: { cookie: sessionCookie, host: 'localhost:8581' },
+          })
+
+          expect(res.statusCode).toBe(200)
+          expect(res.body).toContain(`${origin}/assets/plugin-ui-utils/ui.js`)
+          expect(res.headers['content-security-policy']).toContain(origin)
+        })
+
+        it('rejects an attacker hostname on an allowed development port', async () => {
+          const origin = 'http://attacker.example.com:4200'
+          const res = await app.inject({
+            method: 'GET',
+            path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent(origin)}`,
+            headers: { cookie: sessionCookie, host: 'localhost:8581' },
+          })
+
+          expect(res.statusCode).toBe(200)
+          expect(res.body).not.toContain(origin)
+          expect(res.headers['content-security-policy']).not.toContain(origin)
+          expect(res.body).toContain('src="/assets/plugin-ui-utils/ui.js')
+        })
+
+        it('rejects a matching hostname on a non-development port', async () => {
+          const origin = 'http://localhost:4444'
+          const res = await app.inject({
+            method: 'GET',
+            path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent(origin)}`,
+            headers: { cookie: sessionCookie, host: 'localhost:8581' },
+          })
+
+          expect(res.statusCode).toBe(200)
+          expect(res.body).not.toContain(origin)
+          expect(res.headers['content-security-policy']).not.toContain(origin)
+          expect(res.body).toContain('src="/assets/plugin-ui-utils/ui.js')
+        })
+
+        it('rejects an origin containing an XSS payload', async () => {
+          const xssOrigin = '"></' + 'script><script>alert(document.domain)</script>'
+          const res = await app.inject({
+            method: 'GET',
+            path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent(xssOrigin)}`,
+            headers: { cookie: sessionCookie, host: 'localhost:8581' },
+          })
+
+          expect(res.statusCode).toBe(200)
+          expect(res.body).not.toContain('alert(document.domain)')
+          expect(res.body).toContain('src="/assets/plugin-ui-utils/ui.js')
+        })
+
+        it('rejects a non-http origin', async () => {
+          const origin = 'javascript:alert(1)'
+          const res = await app.inject({
+            method: 'GET',
+            path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent(origin)}`,
+            headers: { cookie: sessionCookie, host: 'localhost:8581' },
+          })
+
+          expect(res.statusCode).toBe(200)
+          expect(res.body).not.toContain(origin)
+          expect(res.body).toContain('src="/assets/plugin-ui-utils/ui.js')
+        })
+      })
     })
 
-    expect(res.statusCode).toBe(404)
-  })
+    describe('asset handling', () => {
+      it('returns 404 when the plugin has no custom UI', async () => {
+        const res = await app.inject({
+          method: 'GET',
+          path: '/plugins/settings-ui/homebridge-mock-plugin-two/index.html',
+          headers: { cookie: sessionCookie },
+        })
 
-  it('GET /plugins/settings-ui/:plugin-name/../../../etc/passwd (path traversal blocked)', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      path: '/plugins/settings-ui/homebridge-mock-plugin/../../../etc/passwd',
-      headers: { cookie: sessionCookie },
+        expect(res.statusCode).toBe(404)
+      })
+
+      it('returns 404 for a missing asset', async () => {
+        const res = await app.inject({
+          method: 'GET',
+          path: '/plugins/settings-ui/homebridge-mock-plugin/nonexistent.html',
+          headers: { cookie: sessionCookie },
+        })
+
+        expect(res.statusCode).toBe(404)
+      })
+
+      it('serves the plugin UI with a version query parameter', async () => {
+        const res = await app.inject({
+          method: 'GET',
+          path: '/plugins/settings-ui/homebridge-mock-plugin/?v=1.0.0',
+          headers: { cookie: sessionCookie },
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(res.body).toContain('Hello World')
+      })
     })
 
-    // Should not return 200 with file contents
-    expect(res.statusCode).not.toBe(200)
-  })
+    describe('path and plugin validation', () => {
+      it('blocks path traversal', async () => {
+        const res = await app.inject({
+          method: 'GET',
+          path: '/plugins/settings-ui/homebridge-mock-plugin/../../../etc/passwd',
+          headers: { cookie: sessionCookie },
+        })
 
-  it('GET /plugins/settings-ui/:plugin-name/ (nonexistent plugin)', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      path: '/plugins/settings-ui/homebridge-nonexistent-plugin/',
-      headers: { cookie: sessionCookie },
+        // Should not return 200 with file contents
+        expect(res.statusCode).not.toBe(200)
+      })
+
+      it('returns 404 for a nonexistent plugin', async () => {
+        const res = await app.inject({
+          method: 'GET',
+          path: '/plugins/settings-ui/homebridge-nonexistent-plugin/',
+          headers: { cookie: sessionCookie },
+        })
+
+        expect(res.statusCode).toBe(404)
+      })
     })
-
-    expect(res.statusCode).toBe(404)
-  })
-
-  it('GET /plugins/settings-ui/:plugin-name/nonexistent.html (missing file)', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      path: '/plugins/settings-ui/homebridge-mock-plugin/nonexistent.html',
-      headers: { cookie: sessionCookie },
-    })
-
-    expect(res.statusCode).toBe(404)
-  })
-
-  it('GET /plugins/settings-ui/:plugin-name/ with version query param', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      path: '/plugins/settings-ui/homebridge-mock-plugin/?v=1.0.0',
-      headers: { cookie: sessionCookie },
-    })
-
-    expect(res.statusCode).toBe(200)
-    expect(res.body).toContain('Hello World')
   })
 
   describe('PluginsSettingsUiService', () => {

--- a/test/e2e/plugin-settings-ui.e2e-spec.ts
+++ b/test/e2e/plugin-settings-ui.e2e-spec.ts
@@ -244,17 +244,47 @@ describe('PluginsSettingsUiController (e2e)', () => {
   it('GET /plugins/settings-ui/:plugin-name/index.html (matching dev server origin → allowed)', async () => {
     // `npm run dev` serves the UI on 4200 while the API answers on 8581, so a
     // relative path would not find the asset. Same host, dev port, so allowed.
-    process.env.UIX_DEVELOPMENT = '1'
-    const res = await app.inject({
-      method: 'GET',
-      path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent('http://localhost:4200')}`,
-      headers: { cookie: sessionCookie, host: 'localhost:8581' },
-    })
-    delete process.env.UIX_DEVELOPMENT
+    const previousDevelopment = process.env.UIX_DEVELOPMENT
+    try {
+      process.env.UIX_DEVELOPMENT = '1'
+      const res = await app.inject({
+        method: 'GET',
+        path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent('http://localhost:4200')}`,
+        headers: { cookie: sessionCookie, host: 'localhost:8581' },
+      })
 
-    expect(res.statusCode).toBe(200)
-    expect(res.body).toContain('http://localhost:4200/assets/plugin-ui-utils/ui.js')
-    expect(res.headers['content-security-policy']).toContain('http://localhost:4200')
+      expect(res.statusCode).toBe(200)
+      expect(res.body).toContain('http://localhost:4200/assets/plugin-ui-utils/ui.js')
+      expect(res.headers['content-security-policy']).toContain('http://localhost:4200')
+    } finally {
+      if (previousDevelopment === undefined) {
+        delete process.env.UIX_DEVELOPMENT
+      } else {
+        process.env.UIX_DEVELOPMENT = previousDevelopment
+      }
+    }
+  })
+
+  it('GET /plugins/settings-ui/:plugin-name/index.html (matching dev server origin in production → ignored)', async () => {
+    const previousDevelopment = process.env.UIX_DEVELOPMENT
+    try {
+      delete process.env.UIX_DEVELOPMENT
+
+      const res = await app.inject({
+        method: 'GET',
+        path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent('http://localhost:4200')}`,
+        headers: { cookie: sessionCookie, host: 'localhost:8581' },
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(res.body).not.toContain('http://localhost:4200')
+      expect(res.headers['content-security-policy']).not.toContain('http://localhost:4200')
+      expect(res.body).toContain('src="/assets/plugin-ui-utils/ui.js')
+    } finally {
+      if (previousDevelopment !== undefined) {
+        process.env.UIX_DEVELOPMENT = previousDevelopment
+      }
+    }
   })
 
   it('GET /plugins/settings-ui/:plugin-name/index.html (XSS via origin → rejected)', async () => {
@@ -382,6 +412,19 @@ describe('PluginsSettingsUiController (e2e)', () => {
       const html = await pluginsSettingsUiService.buildIndexHtml(pluginUi as any, 'javascript:alert(1)')
 
       expect(html).not.toContain('javascript:alert(1)')
+      expect(html).toContain('src="/assets/plugin-ui-utils/ui.js')
+    })
+
+    it('buildIndexHtml should reject an http origin outside the development ports', async () => {
+      const pluginUi = {
+        plugin: { name: 'homebridge-mock-plugin' },
+        publicPath: resolve(pluginsPath, 'homebridge-mock-plugin/homebridge-ui/public'),
+        serverPath: resolve(pluginsPath, 'homebridge-mock-plugin/homebridge-ui/server'),
+      }
+
+      const html = await pluginsSettingsUiService.buildIndexHtml(pluginUi as any, 'https://evil.example.com')
+
+      expect(html).not.toContain('https://evil.example.com')
       expect(html).toContain('src="/assets/plugin-ui-utils/ui.js')
     })
 

--- a/test/e2e/plugin-settings-ui.e2e-spec.ts
+++ b/test/e2e/plugin-settings-ui.e2e-spec.ts
@@ -303,8 +303,8 @@ describe('PluginsSettingsUiController (e2e)', () => {
         })
 
         it('allows a matching development-server origin', async () => {
-        // `npm run dev` serves the UI on 4200 while the API answers on 8581, so a
-        // relative path would not find the asset. Same host, dev port, so allowed.
+          // `npm run dev` serves the UI on 4200 while the API answers on 8581, so a
+          // relative path would not find the asset. Same host, dev port, so allowed.
           const origin = 'http://localhost:4200'
           const res = await app.inject({
             method: 'GET',

--- a/test/e2e/plugin-settings-ui.e2e-spec.ts
+++ b/test/e2e/plugin-settings-ui.e2e-spec.ts
@@ -244,11 +244,13 @@ describe('PluginsSettingsUiController (e2e)', () => {
   it('GET /plugins/settings-ui/:plugin-name/index.html (matching dev server origin → allowed)', async () => {
     // `npm run dev` serves the UI on 4200 while the API answers on 8581, so a
     // relative path would not find the asset. Same host, dev port, so allowed.
+    process.env.UIX_DEVELOPMENT = '1'
     const res = await app.inject({
       method: 'GET',
       path: `/plugins/settings-ui/homebridge-mock-plugin/index.html?origin=${encodeURIComponent('http://localhost:4200')}`,
       headers: { cookie: sessionCookie, host: 'localhost:8581' },
     })
+    delete process.env.UIX_DEVELOPMENT
 
     expect(res.statusCode).toBe(200)
     expect(res.body).toContain('http://localhost:4200/assets/plugin-ui-utils/ui.js')

--- a/ui/src/app/core/plugins/custom-plugins/custom-plugins.component.ts
+++ b/ui/src/app/core/plugins/custom-plugins/custom-plugins.component.ts
@@ -18,6 +18,7 @@ import { ManagePluginsService } from '@/app/core/plugins/manage-plugins.service'
 import { SettingsService } from '@/app/core/ui/settings.service'
 import { ChildBridgesService } from '@/app/core/utilities/child-bridges.service'
 import { environment } from '@/environments/environment'
+import { isDevMode } from '@angular/core'
 
 @Component({
   selector: 'app-custom-plugins',
@@ -261,7 +262,18 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
       return
     }
 
-    this.iframe.src = `${environment.api.base + this.basePath}/index.html?origin=${encodeURIComponent(location.origin)}&v=${encodeURIComponent(plugin.installedVersion)}`
+    const url = new URL(
+      `${environment.api.base + this.basePath}/index.html`,
+      location.origin,
+    )
+
+    if (isDevMode()) {
+      url.searchParams.set('origin', location.origin)
+    }
+
+    url.searchParams.set('v', plugin.installedVersion)
+
+    this.iframe.src = url.toString()
   }
 
   private handleMessage = (e: MessageEvent): void => {

--- a/ui/src/app/core/plugins/custom-plugins/custom-plugins.component.ts
+++ b/ui/src/app/core/plugins/custom-plugins/custom-plugins.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, inject, OnDestroy, OnInit, signal, viewChild } from '@angular/core'
+import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, inject, isDevMode, OnDestroy, OnInit, signal, viewChild } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal'
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip'
@@ -18,7 +18,6 @@ import { ManagePluginsService } from '@/app/core/plugins/manage-plugins.service'
 import { SettingsService } from '@/app/core/ui/settings.service'
 import { ChildBridgesService } from '@/app/core/utilities/child-bridges.service'
 import { environment } from '@/environments/environment'
-import { isDevMode } from '@angular/core'
 
 @Component({
   selector: 'app-custom-plugins',


### PR DESCRIPTION
Significantly cleaner origin fix

Thinking about it, and realized that the origin is only needed when running in development mode with `npm run watch`, so changed then code to only evaluate origin when in development mode aka `UIX_DEVELOPMENT=1`.  Also the Browser will only send origin when running in Angular Dev mode now.