### PR TITLE
fix(status): support degrees as well as millidegrees in the configured cpu temp file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to `homebridge-config-ui-x` will be documented in this file.
 - fix(accessories): paint an unsaturated bulb white rather than grey, on both hap and matter
 - fix(ui): sanitise rendered markdown to prevent stored XSS
 - feat(log): let admins restrict the Homebridge log to administrators
+- fix(status): support degrees as well as millidegrees in the configured cpu temp file (#2896) (@lidonius1122)
 
 ### Other Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to `homebridge-config-ui-x` will be documented in this file.
 - fix(ui): sanitise rendered markdown to prevent stored XSS
 - feat(log): let admins restrict the Homebridge log to administrators
 - fix(status): support degrees as well as millidegrees in the configured cpu temp file (#2896) (@lidonius1122)
+- fix(ui): show a cpu temperature of zero or below on the widget (#2896) (@lidonius1122)
 
 ### Other Changes
 

--- a/src/core/config/config.interfaces.ts
+++ b/src/core/config/config.interfaces.ts
@@ -148,7 +148,9 @@ export interface HomebridgeUiConfig {
    * above (ignoring the sign) is taken as millidegrees and divided by 1000,
    * anything smaller is taken as degrees. The trade-off is that a millidegrees
    * file reporting below 1°C - 999 or less in magnitude - is read as whole
-   * degrees instead.
+   * degrees instead. That direction is deliberate: guessing wrong at the
+   * boundary shows an obviously impossible temperature, below absolute zero,
+   * rather than a plausible-looking wrong one nobody notices.
    */
   temp?: string
   tempUnits?: string

--- a/src/core/config/config.interfaces.ts
+++ b/src/core/config/config.interfaces.ts
@@ -147,7 +147,8 @@ export interface HomebridgeUiConfig {
    * The file may contain either degrees or millidegrees: a reading of 1000 or
    * above (ignoring the sign) is taken as millidegrees and divided by 1000,
    * anything smaller is taken as degrees. The trade-off is that a millidegrees
-   * file reporting below 1°C - 999 or less - is read as whole degrees instead.
+   * file reporting below 1°C - 999 or less in magnitude - is read as whole
+   * degrees instead.
    */
   temp?: string
   tempUnits?: string

--- a/src/core/config/config.interfaces.ts
+++ b/src/core/config/config.interfaces.ts
@@ -142,6 +142,13 @@ export interface HomebridgeUiConfig {
   homebridgeUiUpdatePolicy?: 'all' | 'beta' | 'major' | 'none'
   scheduledRestartCron?: string
   bridges?: HomebridgeUiBridgeConfig[]
+  /**
+   * Path to a file holding the cpu temperature, used in place of auto-detection.
+   * The file may contain either degrees or millidegrees: a reading of 1000 or
+   * above (ignoring the sign) is taken as millidegrees and divided by 1000,
+   * anything smaller is taken as degrees. The trade-off is that a millidegrees
+   * file reporting below 1°C - 999 or less - is read as whole degrees instead.
+   */
   temp?: string
   tempUnits?: string
   wallpaper?: string

--- a/src/modules/status/status.service.ts
+++ b/src/modules/status/status.service.ts
@@ -167,7 +167,16 @@ export class StatusService {
   private async getCpuTempLegacy() {
     try {
       const tempData = await readFile(this.configService.ui.temp, 'utf-8')
-      const cpuTemp = Number.parseInt(tempData, 10) / 1000
+      const tempValue = Number.parseFloat(tempData)
+
+      if (!Number.isFinite(tempValue)) {
+        throw new TypeError('the file does not contain a number')
+      }
+
+      // The configured file may hold either degrees or millidegrees, so pick the
+      // unit by magnitude - no cpu runs at 1000°C, and a millidegrees reading is
+      // never below 1°C in practice (#2896)
+      const cpuTemp = tempValue >= 1000 ? tempValue / 1000 : tempValue
       return {
         main: cpuTemp,
         cores: [],

--- a/src/modules/status/status.service.ts
+++ b/src/modules/status/status.service.ts
@@ -175,8 +175,9 @@ export class StatusService {
 
       // The configured file may hold either degrees or millidegrees, so pick the
       // unit by magnitude - no cpu runs at 1000°C, and a millidegrees reading is
-      // never below 1°C in practice (#2896)
-      const cpuTemp = tempValue >= 1000 ? tempValue / 1000 : tempValue
+      // never within 1°C of zero in practice. The comparison ignores the sign so
+      // a sub-zero millidegrees reading is not mistaken for degrees (#2896)
+      const cpuTemp = Math.abs(tempValue) >= 1000 ? tempValue / 1000 : tempValue
       return {
         main: cpuTemp,
         cores: [],

--- a/test/e2e/status-cpu-temp.e2e-spec.ts
+++ b/test/e2e/status-cpu-temp.e2e-spec.ts
@@ -1,0 +1,154 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import { HttpService } from '@nestjs/axios'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ConfigService } from '../../src/core/config/config.service.js'
+import { HomebridgeIpcService } from '../../src/core/homebridge-ipc/homebridge-ipc.service.js'
+import { Logger } from '../../src/core/logger/logger.service.js'
+import { PluginsService } from '../../src/modules/plugins/plugins.service.js'
+import { ServerService } from '../../src/modules/server/server.service.js'
+import { StatusService } from '../../src/modules/status/status.service.js'
+
+const { cpuTemperatureMock } = vi.hoisted(() => ({
+  cpuTemperatureMock: vi.fn(),
+}))
+
+vi.mock('systeminformation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('systeminformation')>()
+  return {
+    ...actual,
+    cpuTemperature: cpuTemperatureMock,
+  }
+})
+
+describe('StatusService - getCpuTemp', () => {
+  let statusService: StatusService
+  let configService: ConfigService
+  let logger: Logger
+  const tempDir = resolve(__dirname, '../', '.homebridge', 'cpu-temp')
+
+  beforeAll(async () => {
+    await mkdir(tempDir, { recursive: true })
+  })
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+
+    logger = {
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Logger
+
+    configService = {
+      ui: { disableServerMetricsMonitoring: true },
+    } as unknown as ConfigService
+
+    statusService = new StatusService(
+      new HttpService(),
+      logger,
+      configService,
+      {} as PluginsService,
+      {} as ServerService,
+      { on: vi.fn() } as unknown as HomebridgeIpcService,
+    )
+  })
+
+  afterAll(async () => {
+    await rm(tempDir, { force: true, recursive: true })
+  })
+
+  /**
+   * Writes the given contents to a temp file and points `ui.temp` at it
+   */
+  const useTempFile = async (contents: string) => {
+    const tempFile = resolve(tempDir, `temp-${Math.random().toString(36).slice(2)}`)
+    await writeFile(tempFile, contents, 'utf-8')
+    configService.ui.temp = tempFile
+    return tempFile
+  }
+
+  /**
+   * Calls the private temperature lookup the cpu status endpoint is built on
+   */
+  const getCpuTemp = async () => {
+    // @ts-expect-error - accessing private method for testing
+    return statusService.getCpuTemp() as Promise<{ main: number, cores: number[], max: number }>
+  }
+
+  it('should prefer the configured temp file over systeminformation', async () => {
+    // Auto-detection can read the wrong sensor entirely, so an explicitly
+    // configured file must always win, even when cpuTemperature() succeeds
+    cpuTemperatureMock.mockResolvedValue({ main: 88, cores: [88], max: 88 })
+    await useTempFile('47000')
+
+    const cpuTemperature = await getCpuTemp()
+
+    expect(cpuTemperature.main).toBe(47)
+    expect(cpuTemperature.max).toBe(47)
+    expect(cpuTemperatureMock).not.toHaveBeenCalled()
+  })
+
+  it('should use systeminformation when no temp file is configured', async () => {
+    cpuTemperatureMock.mockResolvedValue({ main: 88, cores: [88], max: 88 })
+
+    const cpuTemperature = await getCpuTemp()
+
+    expect(cpuTemperature.main).toBe(88)
+    expect(cpuTemperatureMock).toHaveBeenCalled()
+  })
+
+  describe('temp file parsing', () => {
+    const cases: [string, string, number][] = [
+      ['whole millidegrees', '47000', 47],
+      ['fractional millidegrees', '47500', 47.5],
+      ['whole degrees', '47', 47],
+      ['fractional degrees', '47.5', 47.5],
+      ['a trailing newline', '47000\n', 47],
+    ]
+
+    it.each(cases)('should read %s as %s -> %s°C', async (_label, contents, expected) => {
+      await useTempFile(contents)
+
+      const cpuTemperature = await getCpuTemp()
+
+      expect(cpuTemperature.main).toBe(expected)
+      expect(cpuTemperature.max).toBe(expected)
+      expect(cpuTemperature.cores).toEqual([])
+    })
+  })
+
+  describe('temp file fallbacks', () => {
+    const cases: [string, string][] = [
+      ['does not contain a number', 'abc'],
+      ['is empty', ''],
+      // Infinity and -Infinity survive parseFloat, so they need rejecting too,
+      // else the widget renders a temperature of "Infinity°C"
+      ['reads as infinity', 'Infinity'],
+      ['reads as negative infinity', '-Infinity'],
+    ]
+
+    it.each(cases)('should fall back when the file %s', async (_label, contents) => {
+      await useTempFile(contents)
+
+      const cpuTemperature = await getCpuTemp()
+
+      expect(cpuTemperature.main).toBe(-1)
+      expect(cpuTemperature.max).toBe(-1)
+      expect(logger.error).toHaveBeenCalled()
+    })
+
+    it('should fall back when the file does not exist', async () => {
+      configService.ui.temp = resolve(tempDir, 'does-not-exist')
+
+      const cpuTemperature = await getCpuTemp()
+
+      expect(cpuTemperature.main).toBe(-1)
+      expect(cpuTemperature.max).toBe(-1)
+      expect(logger.error).toHaveBeenCalled()
+    })
+  })
+})

--- a/test/e2e/status-cpu-temp.e2e-spec.ts
+++ b/test/e2e/status-cpu-temp.e2e-spec.ts
@@ -110,6 +110,10 @@ describe('StatusService - getCpuTemp', () => {
       ['a trailing newline', '47000\n', 47],
       ['sub-zero millidegrees', '-5000', -5],
       ['sub-zero degrees', '-5', -5],
+      // The magnitude rule cannot tell a sub-1°C millidegrees reading from a
+      // plain degrees one, so these pin the trade-off discussed in #2896
+      ['millidegrees under the threshold', '999', 999],
+      ['sub-zero millidegrees under the threshold', '-500', -500],
     ]
 
     it.each(cases)('should read %s as %s -> %s°C', async (_label, contents, expected) => {

--- a/test/e2e/status-cpu-temp.e2e-spec.ts
+++ b/test/e2e/status-cpu-temp.e2e-spec.ts
@@ -108,6 +108,8 @@ describe('StatusService - getCpuTemp', () => {
       ['whole degrees', '47', 47],
       ['fractional degrees', '47.5', 47.5],
       ['a trailing newline', '47000\n', 47],
+      ['sub-zero millidegrees', '-5000', -5],
+      ['sub-zero degrees', '-5', -5],
     ]
 
     it.each(cases)('should read %s as %s -> %s°C', async (_label, contents, expected) => {

--- a/ui/src/app/modules/status/widgets/cpu-widget/cpu-widget.component.html
+++ b/ui/src/app/modules/status/widgets/cpu-widget/cpu-widget.component.html
@@ -30,7 +30,8 @@
           </div>
           <div class="widget-value-label grey-text">{{ 'status.cpu.load' | translate }}</div>
         </div>
-        @if (cpuTemperature().main && cpuTemperature().main! > 0) {
+        <!-- -1 is the no-sensor sentinel, everything else is a real reading -->
+        @if (cpuTemperature().main !== undefined && cpuTemperature().main !== null && cpuTemperature().main !== -1) {
           <div class="text-center widget-value-parent-wrap">
             <div class="widget-value mb-0">
               {{ cpuTemperature().main! | convertTemp: temperatureUnits | number: '1.0-0' }}&deg;{{


### PR DESCRIPTION
## :recycle: Current situation

When a custom temperature file is configured via `ui.temp`, `getCpuTempLegacy()` reads it with `Number.parseInt(tempData, 10) / 1000` — a hard millidegrees assumption. A file holding plain degrees (`47`) surfaces as `0.047°C` on the dashboard, `47.5` loses its fraction the same way, and garbage or empty content becomes a silent `NaN` instead of reaching the existing fallback. #2896 documented the file as accepting "either degrees or millidegrees", and since #2896's fix made the configured file authoritative whenever it is set, this parsing path now runs for every `ui.temp` user.

## :bulb: Proposed solution

Building on #2896, which made the configured file the authoritative source, this fixes how the file's contents are interpreted:

- `Number.parseFloat` instead of `parseInt`, so fractional values survive.
- The unit is picked by magnitude: values `>= 1000` are treated as millidegrees (kernel-style `47000`), anything below as plain degrees. The boundary is safe in both directions — no CPU runs at 1000°C, and a millidegrees reading below 1000 would mean a sub-1°C CPU.
- Anything non-finite (`NaN`, `Infinity`) is routed into the existing catch/fallback path (`getCpuTempAlt()`), so the widget hides rather than rendering nonsense. (`parseFloat` would otherwise happily pass `Infinity` through — the previous `parseInt` was accidentally immune.)

Behaviour for existing clean millidegrees files is unchanged, verified by tests that pass both before and after the change.

## :gear: Release Notes

The custom CPU temperature file (`ui.temp`) now accepts values in degrees as well as millidegrees, keeps fractional precision, and falls back cleanly when the file does not contain a usable number.

## :heavy_plus_sign: Additional Information

Since `ui.temp` isn't documented beyond the code itself, the magnitude heuristic effectively specifies the field's semantics now — happy to add a JSDoc note on `config.interfaces.ts` if you'd like that covered here too.

### Testing

New spec `test/e2e/status-cpu-temp.e2e-spec.ts` (12 tests), following the direct-instantiation pattern from `status-nodejs-version.e2e-spec.ts`:

- parsing table: `47000`→47, `47`→47, `47.5`→47.5, `47500`→47.5, trailing newline
- fallback table: non-numeric, empty, `Infinity`, `-Infinity`, missing file → `main: -1`, no crash
- override precedence: a configured file wins over a successful `cpuTemperature()` — this covers the #2896 behaviour, which had no test yet

Full suite passes (648 tests, 28 files), `eslint . --max-warnings=0` clean.

### Reviewer Nudging

Everything lives in `getCpuTempLegacy()` in `src/modules/status/status.service.ts` — the diff is 11 lines; the rest is the new spec and a CHANGELOG line.
