### PR TITLE
fix(plugins): find the running Homebridge when it is installed outside the scanned paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to `homebridge-config-ui-x` will be documented in this file.
 - feat(log): let admins restrict the Homebridge log to administrators
 - fix(status): support degrees as well as millidegrees in the configured cpu temp file (#2896) (@lidonius1122)
 - fix(ui): show a cpu temperature of zero or below on the widget (#2896) (@lidonius1122)
+- fix(plugins): find the running Homebridge when it is installed outside the scanned paths (#2897) (@lidonius1122)
 
 ### Other Changes
 

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -978,6 +978,24 @@ export class PluginsService implements OnModuleDestroy {
   }
 
   /**
+   * Whether the given install path is already among the modules of that name,
+   * compared via realpath so a symlinked duplicate is not added twice
+   */
+  private async containsInstallPath(modules: Array<{ name: string, installPath: string }>, name: string, resolvedPath: string) {
+    for (const module of modules.filter(x => x.name === name)) {
+      try {
+        if (await realpath(module.installPath) === resolvedPath) {
+          return true
+        }
+      } catch (e) {
+        this.logger.debug(`Failed to resolve ${name} install path ${module.installPath} as ${e.message}.`)
+      }
+    }
+
+    return false
+  }
+
+  /**
    * Updates the Homebridge package
    */
   public async updateHomebridgePackage(homebridgeUpdateAction: HomebridgeUpdateActionDto, client: EventEmitter) {
@@ -2066,6 +2084,31 @@ export class PluginsService implements OnModuleDestroy {
         installPath: process.env.UIX_BASE_PATH,
         path: dirname(process.env.UIX_BASE_PATH),
       })
+    }
+
+    // Same for the Homebridge hb-service told us it launched: the apt and Pi image
+    // flavours install to /opt/homebridge, which is not one of the base paths we
+    // scan, so a second copy that is scanned would be the only candidate and every
+    // 'which install is running?' check downstream had nothing to match (#2897).
+    const runningHomebridgePath = this.configService.runningHomebridgeModulePath
+    if (runningHomebridgePath) {
+      let resolvedRunningPath: string
+      try {
+        resolvedRunningPath = await realpath(runningHomebridgePath)
+      } catch (e) {
+        this.logger.debug(`Failed to resolve running Homebridge module path as ${e.message}.`)
+      }
+
+      if (resolvedRunningPath && existsSync(join(resolvedRunningPath, 'package.json'))) {
+        const alreadyFound = await this.containsInstallPath(allModules, 'homebridge', resolvedRunningPath)
+        if (!alreadyFound) {
+          allModules.push({
+            name: 'homebridge',
+            installPath: resolvedRunningPath,
+            path: dirname(resolvedRunningPath),
+          })
+        }
+      }
     }
 
     // If homebridge not found in default locations, check the folder above

--- a/test/e2e/plugins.e2e-spec.ts
+++ b/test/e2e/plugins.e2e-spec.ts
@@ -16,7 +16,7 @@ import { Test } from '@nestjs/testing'
 import { copy, readJson, remove } from 'fs-extra'
 import { of } from 'rxjs'
 import { gt as semverGt } from 'semver'
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AuthModule } from '../../src/core/auth/auth.module.js'
 import { ConfigService } from '../../src/core/config/config.service.js'
@@ -1942,6 +1942,87 @@ describe('PluginController (e2e)', () => {
       await pluginsService.getHomebridgePackage()
 
       expect(configService.homebridgeVersion).toBe('2.1.1')
+    })
+  })
+
+  describe('getInstalledModules - a running install outside the scanned paths (#2897)', () => {
+    let configService: ConfigService
+    let scannedPath: string
+    let unscannedPath: string
+
+    const getInstalledModules = () =>
+      (pluginsService as any).getInstalledModules() as Promise<Array<{ name: string, path: string, installPath: string }>>
+
+    beforeEach(async () => {
+      configService = app.get(ConfigService)
+
+      // The copy the base path scan can see, standing in for the stale second install
+      scannedPath = resolve(process.env.UIX_STORAGE_PATH, 'plugins', 'node_modules', 'homebridge')
+      await mkdir(scannedPath, { recursive: true })
+      await writeFile(join(scannedPath, 'package.json'), JSON.stringify({ name: 'homebridge', version: '2.1.1' }))
+
+      // The one hb-service actually launched, in an /opt/homebridge style location
+      // that is not among the scanned base paths
+      unscannedPath = resolve(process.env.UIX_STORAGE_PATH, 'opt-homebridge', 'lib', 'node_modules', 'homebridge')
+      await mkdir(unscannedPath, { recursive: true })
+      await writeFile(join(unscannedPath, 'package.json'), JSON.stringify({ name: 'homebridge', version: '1.9.0' }))
+
+      configService.runningHomebridgeModulePath = unscannedPath
+    })
+
+    afterEach(async () => {
+      configService.runningHomebridgeModulePath = undefined
+      await remove(resolve(process.env.UIX_STORAGE_PATH, 'opt-homebridge'))
+      await remove(scannedPath)
+    })
+
+    // Regression: the scan only ever returned installs under the base paths, so the
+    // apt and Pi image location was invisible. findRunningHomebridgeInstall then had
+    // nothing to match and getHomebridgePackage fell back to the first discovered
+    // install - the copy that is not running.
+    it('includes the running install so it can be matched', async () => {
+      const modules = await getInstalledModules()
+      const homebridgeInstalls = modules.filter(x => x.name === 'homebridge')
+
+      expect(homebridgeInstalls.some(x => x.installPath === unscannedPath)).toBe(true)
+    })
+
+    it('reports the running version rather than the discovered one', async () => {
+      const homebridge = await pluginsService.getHomebridgePackage()
+
+      expect(homebridge.installedVersion).toBe('1.9.0')
+      expect(configService.homebridgeVersion).toBe('1.9.0')
+    })
+
+    it('resolves the running path through a symlink without listing it twice', async () => {
+      const linkPath = resolve(process.env.UIX_STORAGE_PATH, 'opt-homebridge-link')
+      await remove(linkPath)
+      await symlink(unscannedPath, linkPath, 'junction')
+      configService.runningHomebridgeModulePath = linkPath
+
+      const modules = await getInstalledModules()
+      const homebridgeInstalls = modules.filter(x => x.name === 'homebridge')
+
+      expect(homebridgeInstalls.filter(x => x.installPath === unscannedPath)).toHaveLength(1)
+      expect(homebridgeInstalls.some(x => x.installPath === linkPath)).toBe(false)
+      await remove(linkPath)
+    })
+
+    it('leaves the scan alone when the running path has no package.json', async () => {
+      configService.runningHomebridgeModulePath = resolve(process.env.UIX_STORAGE_PATH, 'opt-homebridge', 'empty')
+
+      const modules = await getInstalledModules()
+
+      expect(modules.some(x => x.name === 'homebridge' && x.installPath === scannedPath)).toBe(true)
+      expect(modules.some(x => x.installPath.endsWith('empty'))).toBe(false)
+    })
+
+    it('leaves the scan alone when the running path does not exist', async () => {
+      configService.runningHomebridgeModulePath = resolve(process.env.UIX_STORAGE_PATH, 'does-not-exist', 'homebridge')
+
+      const modules = await getInstalledModules()
+
+      expect(modules.some(x => x.name === 'homebridge' && x.installPath === scannedPath)).toBe(true)
     })
   })
 


### PR DESCRIPTION
## :recycle: Current situation

`getHomebridgePackage()` (fixed in #2897 / 63c4a13b) now correctly prefers the Homebridge install that `hb-service` reported over IPC as the one it actually launched — but only among the installs that `getInstalledModules()` already found on disk. That scan only looks inside a fixed set of base paths (global `node_modules`, the plugin path, etc.), and the apt and Raspberry Pi image packaging flavours install Homebridge to `/opt/homebridge`, which is not one of them.

So when a Pi/apt user also has a second Homebridge copy sitting somewhere the scan *does* reach — as the reporter's Homebridge Pi image does, via the auto-reinstalling `/var/lib/homebridge` copy their startup script maintains — the running `/opt/homebridge` install never makes it into the candidate list at all. `findRunningHomebridgeInstall()` has nothing to match against, returns `null`, and the UI silently falls back to the first discovered (non-running) install — reporting, and updating, the wrong copy.

This is the gap Ben already called out himself while investigating #2897: *"your running copy sits outside the paths it scans"* — and it's why the reporter confirmed on `5.27.1-beta.21` that the mismatch was still happening after 63c4a13b landed (starts on 1.9.0, UI reports 2.2.1).

## :bulb: Proposed solution

63c4a13b already established the right pattern for this exact problem one level up — the UI's own running install is unconditionally added to the scan results (`getInstalledModules()`, the `runningUiPath` block), so it's always a candidate even when it lives outside the scanned base paths.

This PR applies the same pattern to the Homebridge install `hb-service` reports over IPC: if `configService.runningHomebridgeModulePath` is set, its `realpath` is resolved and — provided a `package.json` exists there and it isn't already present under a different (e.g. symlinked) path — added to `allModules` as a `homebridge` candidate. That gives `findRunningHomebridgeInstall()` something to match again on packaging flavours where the running copy sits outside the scanned paths, which was the missing piece for the reporter's setup.

A small helper, `containsInstallPath`, does the realpath-based duplicate check (mirrors `findRunningHomebridgeInstall`'s own realpath comparison right above it). Failure modes are handled the same way the rest of this function already does: an unresolvable path or a missing `package.json` is logged at debug level and simply leaves the existing scan results untouched, never overwrites what was already found.

One deliberate behavioural consequence worth stating explicitly: on these setups the "Update Homebridge" action now targets the running install too, since the matched candidate carries its `installPath` — previously the update went to the non-running copy, which is the "deeper bug" you mentioned wanting to address in the UI. On setups where the running copy is inside the scanned paths, nothing changes.

## :gear: Release Notes

fix(plugins): find the running Homebridge when it is installed outside the scanned paths (#2897)

## :heavy_plus_sign: Additional Information

### Testing

- Added `test/e2e/plugins.e2e-spec.ts` → `getInstalledModules - a running install outside the scanned paths (#2897)`, covering: the running install is included and matched; `getHomebridgePackage()` reports its version rather than the discovered one; a symlinked running path resolves to the same entry rather than being listed twice; the scan is left untouched when the running path has no `package.json` or doesn't exist.
- This lives in its own `describe` block rather than inside the existing `getHomebridgePackage - which install sets the version (#2897)` block above it, because that block's `beforeEach` mocks `getInstalledModules()` directly — which is exactly the function this fix changes, so a test added there would exercise the mock, not the new code.
- Full suite: 676/676 passing. Lint: clean.

### Reviewer Nudging

The whole change is the new block at the end of `getInstalledModules()` plus the `containsInstallPath` helper right below `findRunningHomebridgeInstall()` — reading it next to the existing `runningUiPath` block above it is the quickest way in. Happy to add a short note to the `getInstalledModules()` JSDoc if you'd like the "why a homebridge-config-ui-x candidate and a homebridge candidate are both force-included" reasoning spelled out in one place rather than split across the two comment blocks — didn't want to touch your existing comment without asking first.
