### PR TITLE
Fix: custom ui canvas follows theme changes.

### DIFF
--- a/ui/src/app/core/plugins/custom-plugins/custom-plugins.component.ts
+++ b/ui/src/app/core/plugins/custom-plugins/custom-plugins.component.ts
@@ -513,12 +513,11 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
       sourceWindow.postMessage({ action: 'inline-style', style: css.innerHTML }, event.origin)
     }
 
-    // Add custom CSS
+    // Add custom CSS. Canvas colors come from the mirrored theme stylesheets (the &.modal-content rule in the theme mixins), so only the
+    // iframe-specific layout override lives here.
     const customStyles = `
       body {
         height: unset !important;
-        background-color: ${darkMode ? '#242424' : '#FFFFFF'} !important;
-        color: ${darkMode ? '#FFFFFF' : '#000000'} !important;
       }
     `
     sourceWindow.postMessage({ action: 'inline-style', style: customStyles }, event.origin)

--- a/ui/src/app/core/ui/settings.service.ts
+++ b/ui/src/app/core/ui/settings.service.ts
@@ -158,9 +158,6 @@ export class SettingsService {
             if (!iframeBody.classList.contains('dark-mode')) {
               iframeBody.classList.add('dark-mode')
             }
-
-            iframeBody.style.backgroundColor = '#242424 !important'
-            iframeBody.style.color = '#ffffff !important'
           } else {
             if (!iframeBody.classList.contains(`config-ui-x-${this.theme}`)) {
               iframeBody.classList.add(`config-ui-x-${this.theme}`)
@@ -171,18 +168,7 @@ export class SettingsService {
             if (iframeBody.classList.contains('dark-mode')) {
               iframeBody.classList.remove('dark-mode')
             }
-
-            iframeBody.style.backgroundColor = '#ffffff !important'
-            iframeBody.style.color = '#000000 !important'
           }
-
-          // Theme update is a non-sensitive payload; use '*' as targetOrigin
-          // so cross-origin plugin iframes (which the same-origin string
-          // would silently skip) also receive it.
-          iframe.contentWindow?.postMessage(
-            { type: 'theme-update', isDark: this.actualLightingMode === 'dark', theme },
-            '*',
-          )
         }
       } catch (e) {
         console.warn(`Iframe ${index}: Access denied (cross-origin?)`, { error: e, src: iframe.src })

--- a/ui/src/scss/themes/themes-dark.scss
+++ b/ui/src/scss/themes/themes-dark.scss
@@ -407,6 +407,15 @@
       opacity: 0.8;
     }
 
+    // The plugin custom UI iframe body carries this theme class and modal-content together on one element, so this compound selector paints its
+    // canvas (the descendant modal selectors above cannot match it). It can match nothing else: in the parent document the theme class exists only
+    // on the body element, which is never given modal-content. The important flag keeps the canvas authoritative over the base styles the iframe
+    // mirrors from the parent document.
+    &.modal-content {
+      background-color: $modalBackground !important;
+      color: #ffffff !important;
+    }
+
     .table {
       color: #ffffff;
     }

--- a/ui/src/scss/themes/themes-light.scss
+++ b/ui/src/scss/themes/themes-light.scss
@@ -20,6 +20,13 @@
       cursor: not-allowed;
     }
 
+    // The plugin custom UI iframe body carries this theme class and modal-content together on one element; this paints its canvas (see the
+    // dark theme mixin for the full rationale).
+    &.modal-content {
+      background-color: #ffffff !important;
+      color: #000000 !important;
+    }
+
     .sidebar {
       background: $primary-dark;
       color: #eeeeee;


### PR DESCRIPTION
## Summary

Open any plugin's custom settings UI and toggle light/dark - or let the OS flip appearance with the theme on auto - and the surrounding UI re-themes while the plugin iframe's canvas keeps its load-time background and text colors. Any plugin UI that doesn't paint its own body surface is affected.

Two mechanisms were supposed to handle this, and both are inert. The theme walk in settings.service.ts writes inline colors of the form el.style.backgroundColor = '#242424 !important' - and a value containing !important assigned through a CSSOM property is silently dropped per spec (priority has to travel as setProperty's third argument), so those four writes have never done anything. Easy to see in any console: the assignment form leaves the property empty, the setProperty form sets it. Meanwhile injectDefaultStyles posts a body { ... !important } block into the iframe once at load, carrying the theme as it stood at that moment, and nothing ever refreshes it. The theme classes do toggle correctly on the iframe body on every change - but the stale !important block outranks anything the classes could drive, so the canvas stays frozen.

The root cause sits a level deeper than either symptom: the theme mixins paint modal surfaces with descendant selectors (.config-ui-x-<name> .modal-body), which can never match the iframe body, where the theme class and modal-content sit together on one element. The hardcoded hex block was compensating for that selector-shape gap.

## The fix

- Theme mixins: each gains one compound rule, &.modal-content, painting the canvas - the dark theme reuses its existing $modalBackground. The rule can only ever match the plugin iframe body: nothing else pairs a theme class and modal-content on a single element, since the theme class otherwise exists only on <body>, which is never given modal-content. Theming now flows entirely through the class toggles plus the mirrored stylesheets - the same mechanism as the rest of the UI - and there is no snapshot left to go stale.
- Injected styles: the block shrinks to its one genuinely iframe-specific job, height: unset. The four no-op CSSOM writes are deleted.
- Removed the theme-update postMessage sent to every iframe on theme change. Nothing has ever received it - plugin-ui-utils' message switch has no case for it and falls through to its default log - it was never documented as a plugin-facing hook, and its comment's cross-origin-delivery claim was structurally false: the send sat inside the if (iframeDoc) guard, which a cross-origin iframe never passes. If a theme hook for plugin UIs is ever wanted, it starts in plugin-ui-utils with a documented handler and a sender built against it.

An intentional cascade change: the compound selector at (0,2,0) now outranks a plugin's own more-specific !important body rule, which previously could beat the plain injected body block. A plugin painting its canvas without !important behaves exactly as before.
