### PR TITLE
fix(plugins): keep the stable update when the requested dist-tag is missing

### DIFF
--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -2288,6 +2288,13 @@ export class PluginsService implements OnModuleDestroy {
     const targetTag = preferBetas && !installedTag ? 'beta' : installedTag
     const candidate = versions.tags[targetTag]
 
+    // Most packages publish no prerelease tag, so there is nothing to compare
+    // against. Returning here keeps the caller's stable result and stops the
+    // comparisons below from being handed an undefined version.
+    if (!candidate) {
+      return
+    }
+
     // Offer the prerelease only when it is the newest thing available. A
     // prerelease sorts below its own release (1.2.4-beta.5 < 1.2.4), so once the
     // stable overtakes the beta line we keep the stable rather than sending a
@@ -2295,7 +2302,7 @@ export class PluginsService implements OnModuleDestroy {
     // would also be left in place while the beta preference was ignored, which
     // is how a beta user ended up being offered, and shown release notes for,
     // the stable version.
-    const beatsInstalled = candidate && gt(candidate, plugin.installedVersion)
+    const beatsInstalled = gt(candidate, plugin.installedVersion)
     const beatsStable = !plugin.updateAvailable || gt(candidate, plugin.latestVersion)
 
     if (beatsInstalled && beatsStable) {

--- a/test/e2e/plugins.e2e-spec.ts
+++ b/test/e2e/plugins.e2e-spec.ts
@@ -1525,7 +1525,7 @@ describe('PluginController (e2e)', () => {
       expect(plugin.updateAvailable).toBe(false)
     })
 
-    it('keeps the stable when the requested tag does not exist', async () => {
+    it('keeps the stable when the requested tag does not exist (#2982)', async () => {
       // Most packages publish no beta tag, so the candidate is undefined. Only
       // beatsInstalled guarded it, leaving beatsStable to call gt(undefined) as
       // soon as a stable update existed, which aborted the whole npm lookup.

--- a/test/e2e/plugins.e2e-spec.ts
+++ b/test/e2e/plugins.e2e-spec.ts
@@ -1524,6 +1524,33 @@ describe('PluginController (e2e)', () => {
 
       expect(plugin.updateAvailable).toBe(false)
     })
+
+    it('keeps the stable when the requested tag does not exist', async () => {
+      // Most packages publish no beta tag, so the candidate is undefined. Only
+      // beatsInstalled guarded it, leaving beatsStable to call gt(undefined) as
+      // soon as a stable update existed, which aborted the whole npm lookup.
+      const plugin = await check({
+        installed: '11.29.0',
+        stable: '11.29.3',
+        preferBetas: true,
+      })
+
+      expect(plugin.latestVersion).toBe('11.29.3')
+      expect(plugin.updateAvailable).toBe(true)
+      expect(plugin.updateTag).toBeNull()
+    })
+
+    it('reports no update when the requested tag does not exist', async () => {
+      const plugin = await check({
+        installed: '11.29.3',
+        stable: '11.29.3',
+        preferBetas: true,
+      })
+
+      expect(plugin.latestVersion).toBe('11.29.3')
+      expect(plugin.updateAvailable).toBe(false)
+      expect(plugin.updateTag).toBeNull()
+    })
   })
 
   describe('getAllowedInstallScripts (#2909)', () => {


### PR DESCRIPTION
Fixes #2982.

## Problem

`checkForBetaUpdates()` reads a dist-tag candidate, then compares it twice — but only one comparison guards it:

```ts
const candidate = versions.tags[targetTag] // undefined when the tag is absent

const beatsInstalled = candidate && gt(candidate, plugin.installedVersion) // guarded
const beatsStable = !plugin.updateAvailable || gt(candidate, plugin.latestVersion) // not guarded
```

`beatsStable` only reaches `gt()` when `plugin.updateAvailable` is true, and the caller sets that from the stable release immediately before delegating. So for a plugin with betas enabled and no `beta` dist-tag — which is most plugins — the first stable update makes it throw `Invalid version. Must be a string. Got type "undefined"`.

The throw lands in the `catch` in `getPluginFromNpm()`, which logs the lookup as failed and clears `publicPackage`, `latestVersion` and `updateAvailable`. That is why one missing dist-tag takes out three separate pieces of the card at once: `plugin.author` is never assigned so it renders a bare `@`, "Install Alternate Version" is gated on `publicPackage`, and the update button is gated on `updateAvailable` — leaving no way to update the plugin from the UI.

This arrived with 15e6812b, released in 5.28.0. Removing the early `return` on `updateAvailable` is what made the path reachable, so the case that commit set out to support is the one that now throws when there is no beta tag.

## Change

Return as soon as the tag is missing. There is no candidate to compare, and the caller's stable result is already correct:

```ts
if (!candidate) {
  return
}
```

With that in place the `candidate &&` on `beatsInstalled` is redundant, so it goes too. That leaves both comparisons operating on a value that is guaranteed to be defined, removing the asymmetry that caused this.

## Tests

Two cases added to the existing `checkForBetaUpdates` block, reusing its `check` helper — omitting `betaTag` already models a package with only a `latest` tag, so no new scaffolding was needed:

- `keeps the stable when the requested tag does not exist (#2982)` — fails on `latest` at `plugins.service.ts:2299` with the exact error above, passes with this change.
- `reports no update when the requested tag does not exist` — the `updateAvailable === false` path, which passes either way. It pins down the short-circuit that hid this bug until a stable update appeared, so a future refactor can't quietly reintroduce it.

Verified with `npm run test`: **724 passing across 30 files**. `eslint --max-warnings=0` and `tsc -p tsconfig.build.json --noEmit` are both clean.

## Notes

`checkForBetaUpdates()` is also called with `preferBetas: true` for `homebridge` and `homebridge-config-ui-x` under `updatePolicy === 'beta'`. Both currently publish a `beta` tag so neither is hitting this today, but this change covers them if that ever stops being true.

Affected plugin authors can unblock their users immediately, without anyone changing config, with `npm dist-tag add <package>@<version> beta`.
