### PR TITLE
ci: label fork pull requests

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: PR Labeler
 
 on:
-  pull_request: # required for auto labeler
+  pull_request_target: # pull_request gives fork PRs a read-only token, so labelling fails
     types: [opened, reopened, synchronize]
   workflow_dispatch:
 


### PR DESCRIPTION
## Problem

`PR Labeler` fails on every pull request opened from a fork:

```
##[error]HttpError: Resource not accessible by integration
```

`pull_request` gives fork PRs a read-only `GITHUB_TOKEN`, and that cap cannot be raised by a `permissions:` block, so `pr-labeler-action` has no `pull-requests: write` and cannot apply a label. The result is a red check on every external contribution.

Recent examples: #2973, #2966, and #2983. In each case `stale / Labeler` passes while `stale / update_release_draft` (the `PR Labeler` job) fails — the two differ only by trigger.

## Change

Use `pull_request_target`, which is already what the sibling `labeler.yml` in this repo does:

| Workflow | Trigger before | Trigger after |
|---|---|---|
| `labeler.yml` | `pull_request_target` | unchanged |
| `pr-labeler.yml` | `pull_request` | `pull_request_target` |

## Why this is safe

`pull_request_target` is worth scrutiny because it runs with a writable token in the base repo's context, so the usual risk is executing untrusted PR code. That does not apply here: [the reusable workflow](https://github.com/homebridge/.github/blob/latest/.github/workflows/pr-labeler.yml) has no `actions/checkout` step at all. It reads the PR's branch name and `.github/pr-labeler.yml` from the base repo, then applies a label. No fork-controlled code runs.

This is the same reasoning that already justifies `pull_request_target` in `labeler.yml`, so the change makes the two consistent rather than introducing a new pattern.

## Verification

I can't prove this green from a fork, since the fix only takes effect once it is on `latest` — a `pull_request_target` workflow runs from the base branch, so this PR's own `PR Labeler` run will still use the old trigger and still fail. `labeler.yml` succeeding on the same fork PRs under the identical trigger is the evidence available beforehand.

Both files parse and the triggers now match:

```
pr-labeler.yml: triggers=[pull_request_target, workflow_dispatch] jobs=[stale]
labeler.yml:    triggers=[pull_request_target, workflow_dispatch] jobs=[stale]
```

## Related, but out of scope here

The reusable `pr-labeler.yml` in `homebridge/.github` declares no `permissions:` block, while its `labeler.yml` explicitly sets `contents: read` and `pull-requests: write`. That is a separate hardening opportunity in a workflow shared across the org, so I have raised it as an issue there rather than touching it from this PR.
