### PR TITLE
test(plugins): create the empty running path so the package.json guard is reached

### DIFF
--- a/test/e2e/plugins.e2e-spec.ts
+++ b/test/e2e/plugins.e2e-spec.ts
@@ -2036,7 +2036,9 @@ describe('PluginController (e2e)', () => {
     })
 
     it('leaves the scan alone when the running path has no package.json', async () => {
-      configService.runningHomebridgeModulePath = resolve(process.env.UIX_STORAGE_PATH, 'opt-homebridge', 'empty')
+      const emptyPath = resolve(process.env.UIX_STORAGE_PATH, 'opt-homebridge', 'empty')
+      await mkdir(emptyPath, { recursive: true })
+      configService.runningHomebridgeModulePath = emptyPath
 
       const modules = await getInstalledModules()
 


### PR DESCRIPTION
One of the tests I added in #2973 never reached the check it was named after. `leaves the scan alone when the running path has no package.json` points `runningHomebridgeModulePath` at `opt-homebridge/empty`, which no fixture creates, so `realpath()` throws ENOENT and it lands in the same branch as the `does not exist` case below it.

Creating the directory puts it on the branch its name describes. Removing the `existsSync(join(resolvedRunningPath, 'package.json'))` condition from `getInstalledModules()` used to leave all 108 tests in the file green; now it fails exactly this one.

No production change, and nothing to clean up: the block's `afterEach` already removes `opt-homebridge` and everything under it. 108 passing, lint clean.
