### PR TITLE
test(auth): pin the over-age token asymmetry the interceptor reacts to

### DIFF
--- a/test/e2e/auth.e2e-spec.ts
+++ b/test/e2e/auth.e2e-spec.ts
@@ -398,6 +398,11 @@ describe('AuthController (e2e)', () => {
       return `hb-refresh=${token}`
     }
 
+    /** The bearer token from a cookie minted by `signUserCookie`. */
+    function signUserToken(overrides: Record<string, any> = {}) {
+      return signUserCookie(overrides).split('=').slice(1).join('=').split(';')[0]
+    }
+
     /** The claims inside a minted access token. */
     function decode(accessToken: string): Record<string, any> {
       return JSON.parse(Buffer.from(accessToken.split('.')[1], 'base64url').toString())
@@ -500,6 +505,32 @@ describe('AuthController (e2e)', () => {
 
       const claims = decode(login.json().access_token)
       expect(claims.sessionStartedAt).toBeGreaterThan(Math.floor(Date.now() / 1000) - 60)
+    })
+
+    // #2981: `refreshToken()` is the only reader of `sessionStartedAt`, so a
+    // token past the cap is refused a renewal while every guarded route still
+    // accepts it. That is what let the browser turn a refused refresh into an
+    // account-wide logout the server then honoured. The fix for that is in the
+    // interceptor and `refreshSession()`, covered by the ui specs; this pins
+    // the server side it reacts to, so the asymmetry cannot be dropped without
+    // a test saying so.
+    it('accepts an over-age token at /auth/check while refusing to renew it', async () => {
+      const overAge = signUserToken({ sessionStartedAt: Math.floor(Date.now() / 1000) - (31 * DAY) })
+
+      const checked = await app.inject({
+        method: 'GET',
+        path: '/auth/check',
+        headers: { authorization: `Bearer ${overAge}` },
+      })
+      expect(checked.statusCode).toBe(200)
+
+      const refreshed = await app.inject({
+        method: 'POST',
+        path: '/auth/refresh',
+        headers: { authorization: `Bearer ${overAge}` },
+      })
+      expect(refreshed.statusCode).toBe(401)
+      expect(refreshed.json().message).toContain('maximum age')
     })
   })
 


### PR DESCRIPTION
The reproduction from #2981, as a test.

`refreshToken()` is the only reader of `sessionStartedAt`, so a token past the 30 day cap is refused a renewal while `/auth/check` still accepts it. That asymmetry is what let the interceptor turn a refused refresh into an account-wide logout the server then honoured. The fix for that is in the interceptor and `refreshSession()`; this pins the server side they react to.

The 31 days are a backdated `sessionStartedAt` rather than elapsed time, so it tests the comparison and nothing about clocks.

I also wrote a second test around the logout itself, over-age token revoking the account and `scope: 'local'` sparing the other device, and dropped it. `/auth/logout` never reads `sessionStartedAt`, so nothing in it depended on the token being over-age; it passed just as happily with a fresh one, and its account-wide half duplicated `keeps other sessions alive when the logout is scoped to this browser`.

Ran the original chain against a beta.3 instance as well, driving the real interceptor rather than a mock: `{"scope":"local"}` on the wire, second device still 200. Reverting both halves of c903c0a5 in a scratch copy puts `{}` back and takes it to 401.

62 passing in the auth e2e file, lint clean. Adding the cap to `validateUser()` fails this test and nothing else in the suite; disabling it in `refreshToken()` fails this plus `refuses to renew a session past its maximum age` and `warns when it refuses a refresh, and stays quiet when it allows one`. The `maximum age` assertion is there because a 401 from an expired or malformed token would otherwise satisfy the same expectation.
