### PR TITLE
Fix Smart Automation configuration persistence

### DIFF
--- a/scripts/extract-plugin-alias.js
+++ b/scripts/extract-plugin-alias.js
@@ -14,6 +14,7 @@ const require = createRequire(import.meta.url)
 
 let pluginAlias
 let pluginType
+const pluginAliases = []
 
 const HomebridgeApiMock = {
   registerPlatform(pluginIdentifier, platformName, constructor) {
@@ -25,6 +26,7 @@ const HomebridgeApiMock = {
     } else {
       pluginAlias = platformName
     }
+    pluginAliases.push({ pluginAlias, pluginType })
   },
   registerAccessory(pluginIdentifier, accessoryName, constructor) {
     pluginType = 'accessory'
@@ -35,6 +37,7 @@ const HomebridgeApiMock = {
     } else {
       pluginAlias = accessoryName
     }
+    pluginAliases.push({ pluginAlias, pluginType })
   },
   version: 2.5,
   serverVersion: '1.2.3',
@@ -179,6 +182,7 @@ async function main() {
     process.send({
       pluginAlias,
       pluginType,
+      pluginAliases,
     }, () => process.exit())
   } catch (e) {
     process.exit(1)

--- a/src/modules/config-editor/config-editor.service.ts
+++ b/src/modules/config-editor/config-editor.service.ts
@@ -352,7 +352,7 @@ export class ConfigEditorService implements OnApplicationBootstrap {
 
     return config[arrayKey].filter((block) => {
       return block[plugin.pluginType] === plugin.pluginAlias
-        || block[plugin.pluginType] === `${pluginName}.${plugin.pluginAlias}`
+        || block[plugin.pluginType] === `${plugin.pluginIdentifier || pluginName}.${plugin.pluginAlias}`
     })
   }
 
@@ -421,7 +421,7 @@ export class ConfigEditorService implements OnApplicationBootstrap {
       let positionIndices: number
 
       const removeExisting = (block: Record<string, any>, index: number) => {
-        if (block[plugin.pluginType] === plugin.pluginAlias || block[plugin.pluginType] === `${pluginName}.${plugin.pluginAlias}`) {
+        if (block[plugin.pluginType] === plugin.pluginAlias || block[plugin.pluginType] === `${plugin.pluginIdentifier || pluginName}.${plugin.pluginAlias}`) {
           positionIndices = index
           return false
         } else {
@@ -860,7 +860,8 @@ export class ConfigEditorService implements OnApplicationBootstrap {
 
   public async updateConfigForPluginWithRestartInfo(pluginName: string, pluginConfig: Record<string, any>[]): Promise<ConfigEditorRestartInfo<Record<string, any>[]>> {
     const saved = await this.updateConfigForPlugin(pluginName, pluginConfig)
-    return this.buildRestartInfo(saved, pluginName)
+    const plugin = await this.pluginsService.getPluginAlias(pluginName)
+    return this.buildRestartInfo(saved, plugin.pluginIdentifier || pluginName)
   }
 
   public async disablePluginWithRestartInfo(pluginName: string): Promise<ConfigEditorRestartInfo<string[]>> {

--- a/src/modules/plugins/plugins.interfaces.ts
+++ b/src/modules/plugins/plugins.interfaces.ts
@@ -203,6 +203,7 @@ export type NpmFunding = { type: string, url: string } | string | Array<{ type: 
 export interface PluginAlias {
   pluginAlias: null | string
   pluginType: null | 'platform' | 'accessory'
+  pluginIdentifier?: string
 }
 
 export interface PluginListNewScopeItem {

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -1866,65 +1866,84 @@ export class PluginsService implements OnModuleDestroy {
     if (!this.installedPlugins) {
       await this.getInstalledPlugins()
     }
-    const plugin = this.installedPlugins.find(x => x.name === pluginName)
-
-    if (!plugin) {
-      throw new NotFoundException()
-    }
-
     const fromCache: PluginAlias | undefined = this.pluginAliasCache.get(pluginName)
     if (fromCache as any) {
       return fromCache
     }
 
-    const output = {
+    const output: PluginAlias = {
       pluginAlias: null,
       pluginType: null,
     }
+    const plugin = this.installedPlugins.find(x => x.name === pluginName)
 
-    if (plugin.settingsSchema) {
+    if (plugin?.settingsSchema) {
       const schema = await this.getPluginConfigSchema(pluginName)
       output.pluginAlias = schema.pluginAlias
       output.pluginType = schema.pluginType
-    } else {
+      output.pluginIdentifier = plugin.name
+    } else if (plugin) {
       try {
-        await new Promise((res, rej) => {
-          const child = fork(resolve(process.env.UIX_BASE_PATH, 'scripts/extract-plugin-alias.js'), {
-            env: {
-              UIX_EXTRACT_PLUGIN_PATH: resolve(plugin.installPath, plugin.name),
-            },
-            stdio: 'ignore',
-          })
-
-          child.once('message', (data: any) => {
-            if (data.pluginAlias && data.pluginType) {
-              output.pluginAlias = data.pluginAlias
-              output.pluginType = data.pluginType
-              res(null)
-            } else {
-              rej(new Error('Invalid Response'))
-            }
-          })
-
-          child.once('close', (code) => {
-            if (code !== 0) {
-              // eslint-disable-next-line unicorn/error-message
-              rej(new Error())
-            }
-          })
-        })
+        const aliases = await this.extractPluginAliases(plugin)
+        Object.assign(output, aliases.at(-1), { pluginIdentifier: plugin.name })
       } catch (e) {
         this.logger.debug(`Failed to extract ${pluginName} plugin alias as ${e.message}.`)
         // Fallback to the manual list, if defined for this plugin
         if (this.pluginAliasHints[pluginName]) {
           output.pluginAlias = this.pluginAliasHints[pluginName].pluginAlias
           output.pluginType = this.pluginAliasHints[pluginName].pluginType
+          output.pluginIdentifier = plugin.name
         }
+      }
+    } else {
+      // The route historically accepted an npm package identifier. Also
+      // accept any platform/accessory alias registered by an installed plugin.
+      for (const candidate of this.installedPlugins) {
+        try {
+          const aliases = await this.extractPluginAliases(candidate)
+          const match = aliases.find(alias => alias.pluginAlias === pluginName)
+          if (match) {
+            Object.assign(output, match, { pluginIdentifier: candidate.name })
+            break
+          }
+        } catch {
+          // Some plugins cannot be safely loaded by the extractor. Continue
+          // searching; this is the same best-effort behaviour as package lookup.
+        }
+      }
+      if (!output.pluginAlias) {
+        throw new NotFoundException()
       }
     }
 
     this.pluginAliasCache.set(pluginName, output)
     return output
+  }
+
+  private extractPluginAliases(plugin: HomebridgePlugin): Promise<PluginAlias[]> {
+    return new Promise((res, rej) => {
+      const child = fork(resolve(process.env.UIX_BASE_PATH, 'scripts/extract-plugin-alias.js'), {
+        env: {
+          UIX_EXTRACT_PLUGIN_PATH: resolve(plugin.installPath, plugin.name),
+        },
+        stdio: 'ignore',
+      })
+
+      child.once('message', (data: any) => {
+        const aliases = Array.isArray(data.pluginAliases)
+          ? data.pluginAliases
+          : [{ pluginAlias: data.pluginAlias, pluginType: data.pluginType }]
+        const valid = aliases.filter((alias: PluginAlias) => alias.pluginAlias && alias.pluginType)
+        valid.length ? res(valid) : rej(new Error('Invalid Response'))
+      })
+
+      child.once('close', (code) => {
+        if (code !== 0) {
+          // eslint-disable-next-line unicorn/error-message
+          rej(new Error())
+        }
+      })
+    })
   }
 
   /**

--- a/test/e2e/config-editor.e2e-spec.ts
+++ b/test/e2e/config-editor.e2e-spec.ts
@@ -173,6 +173,80 @@ describe('ConfigEditorController (e2e)', () => {
     expect(res.json()).toEqual(await readJson(configFilePath))
   })
 
+  it('creates and updates a requested secondary plugin platform alias', async () => {
+    homebridgeConfigService.homebridgeVersion = '2.4.0'
+    const automationConfig = {
+      platform: 'incorrect-client-value',
+      name: 'Smart Automation',
+      _bridge: {
+        name: 'Smart Automation',
+        username: '0E:75:1E:81:C7:1D',
+        pin: '031-45-154',
+      },
+      smartAutomations: [{
+        id: 'automation-1',
+        name: 'Garage Door Ajar',
+        type: 'door-ajar',
+        uniqueIds: ['garage-door'],
+        enabled: true,
+      }],
+    }
+
+    const create = await app.inject({
+      method: 'POST',
+      path: '/config-editor/plugin/smart-automation',
+      headers: { authorization },
+      payload: [automationConfig],
+    })
+
+    expect(create.statusCode).toBe(201)
+    expect(create.json()[0].platform).toBe('smart-automation')
+
+    const savedAfterCreate: HomebridgeConfig = await readJson(configFilePath)
+    expect(savedAfterCreate.platforms.find(block => block.platform === 'config')).toBeDefined()
+    expect(savedAfterCreate.platforms.filter(block => block.platform === 'smart-automation')).toHaveLength(1)
+
+    automationConfig.smartAutomations.push({
+      id: 'automation-2',
+      name: 'Hall Average Temperature',
+      type: 'average-temperature',
+      uniqueIds: ['hall-one', 'hall-two'],
+      enabled: true,
+    })
+    const update = await app.inject({
+      method: 'POST',
+      path: '/config-editor/plugin/smart-automation',
+      headers: { authorization },
+      payload: [automationConfig],
+    })
+    expect(update.statusCode).toBe(201)
+
+    const get = await app.inject({
+      method: 'GET',
+      path: '/config-editor/plugin/smart-automation',
+      headers: { authorization },
+    })
+    expect(get.statusCode).toBe(200)
+    expect(get.json()[0].smartAutomations).toHaveLength(2)
+
+    const savedAfterUpdate: HomebridgeConfig = await readJson(configFilePath)
+    expect(savedAfterUpdate.platforms.filter(block => block.platform === 'smart-automation')).toHaveLength(1)
+    expect(savedAfterUpdate.platforms.find(block => block.platform === 'config')).toBeDefined()
+  })
+
+  it('rejects an alias that the requested plugin does not register', async () => {
+    const before = await readJson(configFilePath)
+    const response = await app.inject({
+      method: 'POST',
+      path: '/config-editor/plugin/not-a-real-platform',
+      headers: { authorization },
+      payload: [{ platform: 'not-a-real-platform' }],
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(await readJson(configFilePath)).toEqual(before)
+  })
+
   it('POST /config-editor (valid config)', async () => {
     const currentConfig: HomebridgeConfig = await readJson(configFilePath)
 

--- a/ui/src/app/modules/smart-automations/smart-automations.component.ts
+++ b/ui/src/app/modules/smart-automations/smart-automations.component.ts
@@ -203,9 +203,8 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
     }
 
     try {
-      const configBlocks = await this.$api.get<ConfigPlatformBlock[]>('/config-editor/plugin/homebridge-config-ui-x')
-      const smartAutomationBlock = configBlocks.find(block => block.platform === SMART_AUTOMATION_PLATFORM)
-        || configBlocks.find(block => block.platform === 'config')
+      const configBlocks = await this.$api.get<ConfigPlatformBlock[]>('/config-editor/plugin/smart-automation')
+      const smartAutomationBlock = configBlocks[0]
       const switches = (smartAutomationBlock?.smartAutomations || []).filter(a => typeof a?.name === 'string')
       this.smartAutomations.set(switches)
       this.debugEnabled.set(smartAutomationBlock?.debug === true)
@@ -220,15 +219,9 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
     }
 
     try {
-      const configBlocks = await this.$api.get<ConfigPlatformBlock[]>('/config-editor/plugin/homebridge-config-ui-x')
-      const engineIndex = configBlocks.findIndex(block => block.platform === SMART_AUTOMATION_PLATFORM)
-      const uiConfigBlock = configBlocks.find(block => block.platform === 'config')
-      const current = engineIndex >= 0 ? configBlocks[engineIndex] : null
-      const bridgeSource = current?._bridge || uiConfigBlock?._bridge
-
-      if (!current && !uiConfigBlock) {
-        return
-      }
+      const configBlocks = await this.$api.get<ConfigPlatformBlock[]>('/config-editor/plugin/smart-automation')
+      const current = configBlocks[0]
+      const bridgeSource = current?._bridge
 
       const nextBridge = {
         ...bridgeSource,
@@ -245,13 +238,7 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
         _bridge: nextBridge,
         smartAutomations: this.smartAutomations().map(automation => ({ ...automation })),
       }
-      if (engineIndex >= 0) {
-        configBlocks[engineIndex] = nextBlock
-      } else {
-        configBlocks.push(nextBlock)
-      }
-
-      await this.$api.post('/config-editor/plugin/homebridge-config-ui-x', configBlocks)
+      await this.$api.post('/config-editor/plugin/smart-automation', [nextBlock])
 
       // The automation engine runs in its own child-bridge process and reads
       // its rules only during startup. Reload just that bridge after every
@@ -260,6 +247,7 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
       await this.$api.put(`/server/restart/${encodeURIComponent(nextBridge.username)}`, {})
     } catch (error) {
       console.error(error)
+      throw error
     }
   }
 


### PR DESCRIPTION
## Summary
- allow the existing plugin configuration API to accept either an npm plugin identifier or a registered platform/accessory alias
- resolve smart-automation back to its owning homebridge-config-ui-x package
- use /config-editor/plugin/smart-automation for Smart Automation reads and writes
- preserve existing package-name behavior and atomic plugin config updates
- keep failed saves from being treated as successful by the form

## Validation
- npm run lint
- npm run build:server
- npm run build:ui
- npm test -- test/e2e/config-editor.e2e-spec.ts (105 tests passed)