### PR TITLE
Expose Smart Automation as an embedded plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "scripts": {
     "prepare": "node scripts/apply-patches.mjs",
     "build": "npm run build:server && npm run build:ui",
-    "build:server": "rimraf dist && tsc -p tsconfig.build.json",
+    "build:server": "rimraf dist && tsc -p tsconfig.build.json && node scripts/build-smart-automation-plugin.mjs",
     "build:ui": "npm run build --prefix ui",
     "postbuild:ui": "node scripts/verify-monaco-assets.mjs",
     "check": "npm run check:server && npm run check:ui",

--- a/scripts/build-smart-automation-plugin.mjs
+++ b/scripts/build-smart-automation-plugin.mjs
@@ -1,0 +1,25 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const rootPackage = JSON.parse(await readFile(resolve('package.json'), 'utf8'))
+const manifest = {
+  name: 'homebridge-smart-automation',
+  displayName: 'Homebridge Smart Automation',
+  private: true,
+  version: rootPackage.version,
+  type: 'module',
+  main: './plugin.js',
+  keywords: [
+    'homebridge-plugin',
+    'supports-hap',
+  ],
+  engines: {
+    node: rootPackage.engines.node,
+    homebridge: rootPackage.engines.homebridge,
+  },
+}
+
+await writeFile(
+  resolve('dist/smart-automation/package.json'),
+  `${JSON.stringify(manifest, null, 2)}\n`,
+)

--- a/src/bin/hb-service.ts
+++ b/src/bin/hb-service.ts
@@ -16,7 +16,7 @@ import { Buffer } from 'node:buffer'
 import { execFileSync, execSync, fork } from 'node:child_process'
 import { randomInt } from 'node:crypto'
 import { chownSync, createReadStream, createWriteStream, existsSync } from 'node:fs'
-import { mkdtemp, open, readFile, rename, stat } from 'node:fs/promises'
+import { mkdtemp, open, readFile, realpath, rename, stat } from 'node:fs/promises'
 import { arch, cpus, homedir, platform, release, tmpdir, type } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import process from 'node:process'
@@ -25,7 +25,7 @@ import { fileURLToPath } from 'node:url'
 
 import axios from 'axios'
 import { program } from 'commander'
-import { mkdirp, pathExists, pathExistsSync, readJson, readJsonSync, remove, writeJson } from 'fs-extra/esm'
+import { ensureSymlink, mkdirp, pathExists, pathExistsSync, readJson, readJsonSync, remove, writeJson } from 'fs-extra/esm'
 import ora from 'ora'
 import { gt, gte, parse } from 'semver'
 import { networkInterfaceDefault, networkInterfaces } from 'systeminformation'
@@ -415,6 +415,8 @@ export class HomebridgeServiceHelper {
       // Get the standalone ui binary on this system
       this.uiBinary = resolve(process.env.UIX_BASE_PATH, 'dist', 'bin', 'standalone.js')
       this.logger.debug(`UI path: ${this.uiBinary}.`)
+
+      await this.exposeSmartAutomationPlugin()
     } catch (e) {
       this.logger.log(e.message)
       process.exit(1)
@@ -439,6 +441,45 @@ export class HomebridgeServiceHelper {
       }, 20000)
     } else {
       this.runHomebridge()
+    }
+  }
+
+  /**
+   * The packaged UI and user plugins live in separate module trees on the
+   * official images. Make the embedded Smart Automation package visible from
+   * Homebridge's single strict plugin path without changing that path or
+   * copying a second installation of the engine.
+   */
+  private async exposeSmartAutomationPlugin(): Promise<void> {
+    const pluginPath = process.env.UIX_CUSTOM_PLUGIN_PATH
+    if (!pluginPath) {
+      return
+    }
+
+    const embeddedPlugin = resolve(process.env.UIX_BASE_PATH, 'dist', 'smart-automation')
+    const embeddedManifest = resolve(embeddedPlugin, 'package.json')
+    if (!await pathExists(embeddedManifest)) {
+      this.logger.warn(`Embedded Smart Automation plugin was not found at ${embeddedPlugin}.`)
+      return
+    }
+
+    const exposedPlugin = resolve(pluginPath, 'homebridge-smart-automation')
+    if (await pathExists(exposedPlugin)) {
+      try {
+        if (await realpath(exposedPlugin) === await realpath(embeddedPlugin)) {
+          return
+        }
+      } catch {}
+
+      this.logger.warn(`Could not expose the embedded Smart Automation plugin because ${exposedPlugin} already exists.`)
+      return
+    }
+
+    try {
+      await ensureSymlink(embeddedPlugin, exposedPlugin, 'junction')
+      this.logger.debug(`Exposed Smart Automation plugin at ${exposedPlugin}.`)
+    } catch (e) {
+      this.logger.warn(`Could not expose the embedded Smart Automation plugin as ${e.message}.`)
     }
   }
 

--- a/src/smart-automation/plugin.ts
+++ b/src/smart-automation/plugin.ts
@@ -1,0 +1,11 @@
+import { SmartAutomationPlatform } from './smart-automation.platform.js'
+
+class EmbeddedSmartAutomationPlatform extends SmartAutomationPlatform {
+  constructor(log: any, config: any, api: any) {
+    super(log, config, api, 'homebridge-smart-automation')
+  }
+}
+
+export default (api) => {
+  api.registerPlatform('homebridge-smart-automation', 'smart-automation', EmbeddedSmartAutomationPlatform)
+}

--- a/src/smart-automation/smart-automation.platform.ts
+++ b/src/smart-automation/smart-automation.platform.ts
@@ -7,7 +7,6 @@ import { SmartLightGroupRulesEngine } from './rules/smart-light-group.rules-engi
 import { HapSmartAutomationAccessoryController } from './smart-automation-accessory.controller.js'
 import { createSmartAutomationLogger, SmartAutomationLogger } from './smart-automation.logger.js'
 
-const PLUGIN_NAME = 'homebridge-config-ui-x'
 const PLATFORM_NAME = 'smart-automation'
 
 export class SmartAutomationPlatform {
@@ -20,6 +19,7 @@ export class SmartAutomationPlatform {
     homebridgeLog: any,
     private readonly config: { debug?: boolean, smartAutomations?: SmartAutomationConfig[] },
     private readonly api: any,
+    private readonly pluginName = 'homebridge-config-ui-x',
   ) {
     this.log = createSmartAutomationLogger(homebridgeLog, this.config.debug === true)
     this.accessoryController = new HapSmartAutomationAccessoryController(this.api?.user?.configPath?.(), this.log)
@@ -93,13 +93,13 @@ export class SmartAutomationPlatform {
     })
 
     if (newAccessories.length) {
-      this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, newAccessories)
+      this.api.registerPlatformAccessories(this.pluginName, PLATFORM_NAME, newAccessories)
     }
     if (existingAccessories.length) {
       this.api.updatePlatformAccessories(existingAccessories)
     }
     if (staleAccessories.length) {
-      this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, staleAccessories)
+      this.api.unregisterPlatformAccessories(this.pluginName, PLATFORM_NAME, staleAccessories)
     }
 
     this.log.info(`Engine ready; published ${publishedAccessories} automation accessor${publishedAccessories === 1 ? 'y' : 'ies'} and started ${this.monitors.length} monitor${this.monitors.length === 1 ? '' : 's'}.`)

--- a/ui/src/app/modules/login/login.component.ts
+++ b/ui/src/app/modules/login/login.component.ts
@@ -29,6 +29,7 @@ export class LoginComponent implements OnInit, AfterViewInit {
   private $auth = inject(AuthService)
   private $router = inject(Router)
   private $settings = inject(SettingsService)
+  private otpFocusTimer?: ReturnType<typeof setTimeout>
   private targetRoute!: string
   private validNonAdminRoutes = [
     '/accessories',
@@ -46,6 +47,14 @@ export class LoginComponent implements OnInit, AfterViewInit {
   public readonly invalid2faCode = signal(false)
   public readonly twoFactorCodeRequired = signal(false)
   public readonly inProgress = signal(false)
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      if (this.otpFocusTimer) {
+        clearTimeout(this.otpFocusTimer)
+      }
+    })
+  }
 
   // Initialize form as property with all controls (including OTP for 2FA)
   // OTP validators are added dynamically when 2FA is required
@@ -145,8 +154,11 @@ export class LoginComponent implements OnInit, AfterViewInit {
         }
 
         this.twoFactorCodeRequired.set(true)
-        setTimeout(() => {
-          document.getElementById('form-ota')?.focus()
+        if (this.otpFocusTimer) {
+          clearTimeout(this.otpFocusTimer)
+        }
+        this.otpFocusTimer = setTimeout(() => {
+          this.otpInput()?.nativeElement.focus()
         }, 100)
       } else {
         this.invalidCredentials.set(true)


### PR DESCRIPTION
## Summary
- build the Smart Automation engine as an embedded homebridge-smart-automation package with its own generated package.json and initializer
- preserve the existing local registration for npm run watch
- have hb-service expose the embedded package through the existing custom plugin directory using a symlink
- keep the single -P plugin path and strict plugin resolution unchanged
- register cached platform accessories under the correct plugin identifier in each environment

## Deployment layout
The packaged engine remains under dist/smart-automation. At startup hb-service links it into the configured plugin directory as homebridge-smart-automation, allowing Docker Homebridge to discover it under --strict-plugin-resolution.

## Validation
- npm run lint
- npm run build:server
- 107 focused tests passed
- embedded package alias extraction verified
- npm tarball includes dist/smart-automation/package.json and plugin.js