### PR TITLE
Add crossorigin attribute to manifest link so manifest is also reachable when using CF tunnels

### DIFF
--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png" />
     <link rel="mask-icon" href="/assets/mask-icon.svg" color="#57277c" />
-    <link rel="manifest" href="/assets/manifest.webmanifest" />
+    <link rel="manifest" href="/assets/manifest.webmanifest" crossorigin="use-credentials" />
     <meta name="theme-color" content="#140a33" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0f0f0f" media="(prefers-color-scheme: dark)" />
   </head>


### PR DESCRIPTION
Added crossorigin attribute to the manifest link. Because otherwise Cloudflare Tunnels blocks it. See https://github.com/open-webui/open-webui/issues/1538 and https://github.com/cloudflare/cloudflare-docs/blob/production/src/content/docs/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/cors.mdx

## :recycle: Current situation

If a user would use CF tunnels as a reverse proxy, CF blocks that (not sure why, not a front-end dev). May be related to: https://github.com/cloudflare/cloudflare-docs/blob/production/src/content/docs/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/cors.mdx

## :bulb: Proposed solution

Add: crossorigin="use-credentials" to the link rel that downloads the webmanifest

## :gear: Release Notes

User now downloads that manifest regardless if they use or not use CF proxy. So they can set a fancy icon on their device (webapp).

## :heavy_plus_sign: Additional Information

not applicable.

### Testing

Browsing mainly through CF tunnel, aswell as directly on IP and port combo.

### Reviewer Nudging

https://github.com/homebridge/homebridge-config-ui-x/pull/3005/changes#diff-cb77270e49b72924fa6a62da3dcb0c269dd75528151aa6059b5ae17cd44c58b2R16
