### PR TITLE
Fix saved names colliding between separate outlets

### DIFF
--- a/ui/src/app/core/accessories/accessories.service.spec.ts
+++ b/ui/src/app/core/accessories/accessories.service.spec.ts
@@ -541,6 +541,45 @@ describe('AccessoriesService', () => {
       })
     }
 
+    it('keeps same-named outlets on different plugs separate through discovery and save', async () => {
+      const plugs = ['PLUG-A', 'PLUG-B'].map((serial, index) => layoutEntry({
+        uniqueId: `plug-${index}`,
+        serial,
+        nameBasedUniqueId: 'shared-outlet-name',
+        customName: `Custom ${index}`,
+      }))
+      await start({ layout: [{ name: 'Kitchen', isDefault: true, services: plugs }] })
+      sendData(...plugs.map(plug => rawHap({
+        uniqueId: plug.uniqueId,
+        nameBasedUniqueId: plug.nameBasedUniqueId,
+        accessoryInformation: { 'Serial Number': plug.serial },
+      })))
+      expect(service.rooms()[0].services.map(s => s.customName)).toEqual(['Custom 0', 'Custom 1'])
+      await service.saveLayout()
+      const saved = io.requests.find(entry => entry.resource === 'save-layout')!.payload.layout[0].services
+      expect(saved.map((s: AccessoryLayoutService) => s.customName)).toEqual(['Custom 0', 'Custom 1'])
+    })
+
+    it('preserves an offline plug when an online plug shares its name-based id', async () => {
+      const plugs = ['PLUG-A', 'PLUG-B'].map((serial, index) => layoutEntry({
+        uniqueId: `plug-${index}`,
+        serial,
+        nameBasedUniqueId: 'shared-outlet-name',
+        customName: `Custom ${index}`,
+      }))
+      await start({ layout: [{ name: 'Kitchen', isDefault: true, services: plugs }] })
+      sendData(rawHap({ uniqueId: 'plug-0', nameBasedUniqueId: 'shared-outlet-name', accessoryInformation: { 'Serial Number': 'PLUG-A' } }))
+      await service.saveLayout()
+      const saved = io.requests.find(entry => entry.resource === 'save-layout')!.payload.layout[0].services
+      expect(saved.map((s: AccessoryLayoutService) => s.customName)).toEqual(['Custom 0', 'Custom 1'])
+    })
+
+    it('does not infer device identity from a shared name when serial numbers are absent', async () => {
+      await withLayout(layoutEntry({ uniqueId: 'old', serial: '', nameBasedUniqueId: 'same-name' }))
+      sendData(rawHap({ uniqueId: 'new', nameBasedUniqueId: 'same-name', accessoryInformation: {} }))
+      expect(idsIn('Hallway')).toEqual([])
+    })
+
     it('prefers nameBasedUniqueId over a changed uniqueId', async () => {
       // uniqueId is only stable within a session, so a restarted child bridge
       // hands back a different one for the same accessory

--- a/ui/src/app/core/accessories/accessories.service.ts
+++ b/ui/src/app/core/accessories/accessories.service.ts
@@ -362,7 +362,7 @@ export class AccessoriesService {
    * Check if a cached service matches a discovered service.
    *
    * Matching priority:
-   * 1. nameBasedUniqueId (stable across sessions, available from hap-client)
+   * 1. nameBasedUniqueId scoped to a nonempty serial number and bridge
    * 2. uniqueId (stable within a session, may change between sessions)
    * 3. Fallback: name + serial + bridge + uuid (legacy layouts without nameBasedUniqueId)
    *
@@ -375,20 +375,25 @@ export class AccessoriesService {
         && cachedService.bridge === (discoveredService.instance?.username || discoveredService.bridge)
     }
 
-    // Primary match: nameBasedUniqueId (stable across sessions)
-    if (cachedService.nameBasedUniqueId && discoveredService.nameBasedUniqueId) {
+    const bridge = discoveredService.instance?.username || discoveredService.bridge
+    const serial = discoveredService.accessoryInformation?.['Serial Number'] || discoveredService.serial
+    if (cachedService.bridge !== bridge || (cachedService.serial && serial && cachedService.serial !== serial)) {
+      return false
+    }
+
+    // Names can be identical on different devices (e.g. two dual-outlet plugs).
+    // Only use a name-based identity after establishing the physical device.
+    const sameDevice = !!cachedService.serial && cachedService.serial === serial
+    if (sameDevice && cachedService.nameBasedUniqueId && discoveredService.nameBasedUniqueId) {
       return cachedService.nameBasedUniqueId === discoveredService.nameBasedUniqueId
     }
 
-    // Secondary match: uniqueId
-    if (cachedService.uniqueId === discoveredService.uniqueId) {
+    if (cachedService.uniqueId && cachedService.uniqueId === discoveredService.uniqueId) {
       return true
     }
 
-    // Fallback: multi-field match for legacy layouts without nameBasedUniqueId
-    return cachedService.name === (discoveredService.serviceName || discoveredService.name)
-      && cachedService.serial === (discoveredService.accessoryInformation?.['Serial Number'] || discoveredService.serial)
-      && cachedService.bridge === (discoveredService.instance?.username || discoveredService.bridge)
+    return sameDevice
+      && cachedService.name === (discoveredService.serviceName || discoveredService.name)
       && cachedService.uuid === discoveredService.uuid
   }
 
@@ -494,7 +499,14 @@ export class AccessoriesService {
    * Get a stable key for a service, preferring nameBasedUniqueId
    */
   private getServiceKey(service: any): string {
-    return service.nameBasedUniqueId || service.uniqueId
+    const bridge = service.instance?.username || service.bridge
+    const serial = service.accessoryInformation?.['Serial Number'] || service.serial
+    if (service.protocol === 'matter' || service.uniqueId?.startsWith('matter:')) {
+      return JSON.stringify([bridge, service.uniqueId])
+    }
+    return service.nameBasedUniqueId && serial
+      ? JSON.stringify([bridge, serial, service.nameBasedUniqueId])
+      : JSON.stringify([bridge, service.uniqueId])
   }
 
   /**


### PR DESCRIPTION
Fixes #3008

Two plugs can expose outlets with the same name identifier. The UI then restores the wrong custom name or drops the offline outlet from the saved layout.

Scope name matching and layout merge keys to the bridge and serial number. Keep the unique ID fallback. Missing serials no longer count as evidence that two outlets belong to the same device.

Verified after rebasing onto `beta-5.29.1` with 85 focused accessory service tests, 4,093 UI tests, 798 backend tests, lint, the production build and Monaco asset validation. An isolated browser run with two virtual HAP plugs covers naming, reload, independent controls, saving while one plug is offline and reconnection. Desktop dark, phone dark and desktop light views passed with no browser errors. All accounts and devices in the test are synthetic.

![Distinct names after reconnection](https://raw.githubusercontent.com/msrivas-7/homebridge-config-ui-x/71d51908/.contributions/screenshots/outlet-names-after-reconnect.png)

Happy to adjust the approach based on feedback.
