### PR TITLE
Mask secret fields in generated plugin forms

### DIFF
--- a/ui/src/app/core/components/schema-form/config-input.component.html
+++ b/ui/src/app/core/components/schema-form/config-input.component.html
@@ -1,0 +1,14 @@
+<div class="position-relative">
+  <input-widget [layoutNode]="inputLayout()" [layoutIndex]="layoutIndex()" [dataIndex]="dataIndex()" />
+  @if (isSecret()) {
+    <button
+      type="button"
+      class="btn btn-link text-reset p-2 m-0 position-absolute end-0 bottom-0"
+      [attr.aria-label]="(revealed() ? 'plugins.config.hide_value' : 'plugins.config.show_value') | translate"
+      [attr.aria-controls]="`control${layoutNode()._id}`"
+      (click)="revealed.set(!revealed())"
+    >
+      <i class="fas fa-fw" aria-hidden="true" [class.fa-eye]="!revealed()" [class.fa-eye-slash]="revealed()"></i>
+    </button>
+  }
+</div>

--- a/ui/src/app/core/components/schema-form/config-input.component.spec.ts
+++ b/ui/src/app/core/components/schema-form/config-input.component.spec.ts
@@ -1,0 +1,95 @@
+import type { ComponentFixture } from '@angular/core/testing'
+
+import { importProvidersFrom } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+import { Bootstrap5FrameworkModule } from '@ng-formworks/bootstrap5'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { SchemaFormComponent } from '@/app/core/components/schema-form/schema-form.component'
+import { makeSettings } from '@/testing'
+import { provideFakes, provideTestTranslate } from '@/testing/providers'
+
+describe('plugin secret inputs', () => {
+  let fixture: ComponentFixture<SchemaFormComponent>
+  const data = () => ({ name: 'Test plugin', password: 'dummy-password', apiKey: 'dummy-api-key', credential: 'dummy-credential' })
+
+  function create(value = data()) {
+    TestBed.configureTestingModule({
+      imports: [SchemaFormComponent],
+      providers: [provideTestTranslate(), provideFakes({ settings: makeSettings() }), importProvidersFrom(Bootstrap5FrameworkModule)],
+    })
+    fixture = TestBed.createComponent(SchemaFormComponent)
+    fixture.componentRef.setInput('configSchema', {
+      schema: {
+        type: 'object',
+        required: ['password'],
+        properties: {
+          name: { type: 'string' },
+          password: { type: 'string', minLength: 8 },
+          apiKey: { type: 'string' },
+          credential: { type: 'string', format: 'password', readOnly: true },
+        },
+      },
+    })
+    fixture.componentRef.setInput('data', value)
+    fixture.detectChanges()
+    return value
+  }
+
+  function input(name: string): HTMLInputElement {
+    return fixture.nativeElement.querySelector(`input[name="${name}"]`)
+  }
+
+  function toggle(control: HTMLInputElement): HTMLButtonElement {
+    return fixture.nativeElement.querySelector(`button[aria-controls="${control.id}"]`)
+  }
+
+  afterEach(() => fixture?.destroy())
+
+  it('masks declared and common secret fields while leaving ordinary input alone', () => {
+    create()
+    expect(input('name').type).toBe('text')
+    expect(toggle(input('name'))).toBeNull()
+    for (const name of ['password', 'apiKey', 'credential']) {
+      expect(input(name).type).toBe('password')
+      expect(input(name).getAttribute('spellcheck')).toBe('false')
+      expect(toggle(input(name)).type).toBe('button')
+    }
+  })
+
+  it('reveals one value without replacing its control or changing form data', () => {
+    const value = create()
+    const password = input('password')
+    toggle(password).click()
+    fixture.detectChanges()
+    expect(input('password')).toBe(password)
+    expect(password.type).toBe('text')
+    expect(input('apiKey').type).toBe('password')
+    expect(value).toEqual(data())
+    toggle(password).click()
+    fixture.detectChanges()
+    expect(password.type).toBe('password')
+    expect(password.value).toBe('dummy-password')
+  })
+
+  it('preserves edits and validation across hide and reveal', async () => {
+    const value = create()
+    const password = input('password')
+    password.value = 'replacement-password'
+    password.dispatchEvent(new Event('input', { bubbles: true }))
+    fixture.detectChanges()
+    await new Promise(resolve => setTimeout(resolve, 120))
+    fixture.detectChanges()
+    toggle(password).click()
+    fixture.detectChanges()
+    expect(password.value).toBe('replacement-password')
+    expect(value.password).toBe('replacement-password')
+    password.value = 'short'
+    password.dispatchEvent(new Event('input', { bubbles: true }))
+    fixture.detectChanges()
+    expect(password.classList.contains('ng-invalid')).toBe(true)
+    toggle(password).click()
+    fixture.detectChanges()
+    expect(password.classList.contains('ng-invalid')).toBe(true)
+  })
+})

--- a/ui/src/app/core/components/schema-form/config-input.component.ts
+++ b/ui/src/app/core/components/schema-form/config-input.component.ts
@@ -1,0 +1,46 @@
+import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core'
+import { JsonSchemaFormModule } from '@ng-formworks/core'
+import { TranslatePipe } from '@ngx-translate/core'
+
+const secretName = /password|passwd|passphrase|secret|token|apikey|privatekey|authorization|credential|^(?:pin|pincode|cookie)$/i
+
+@Component({
+  selector: 'app-config-input',
+  imports: [JsonSchemaFormModule, TranslatePipe],
+  standalone: true,
+  templateUrl: './config-input.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ConfigInputComponent {
+  readonly layoutNode = input.required<any>()
+  readonly layoutIndex = input.required<number[]>()
+  readonly dataIndex = input.required<number[]>()
+  readonly revealed = signal(false)
+  readonly isSecret = computed(() => {
+    const node = this.layoutNode()
+    const name = String(node.name || node.dataPointer?.split('/').at(-1) || '')
+    return node.type === 'password' || secretName.test(name.replace(/[-_\s]/g, ''))
+  })
+
+  // Keep the library's input, validators and form control alive when toggling.
+  readonly inputLayout = computed(() => {
+    const node = this.layoutNode()
+    if (!this.isSecret()) {
+      return node
+    }
+    return {
+      ...node,
+      type: this.revealed() ? 'text' : 'password',
+      options: {
+        ...node.options,
+        'fieldHtmlClass': `${node.options?.fieldHtmlClass || ''} pe-5`,
+        'x-inputAttributes': {
+          ...node.options?.['x-inputAttributes'],
+          spellcheck: 'false',
+          autocapitalize: 'off',
+          autocorrect: 'off',
+        },
+      },
+    }
+  })
+}

--- a/ui/src/app/core/components/schema-form/schema-form.component.html
+++ b/ui/src/app/core/components/schema-form/schema-form.component.html
@@ -5,6 +5,7 @@
       class="ng-bs5-validate"
       [jsfPatch]="configSchema().fixArrays"
       [options]="jsonFormOptions"
+      [widgets]="widgets"
       [schema]="configSchema().schema"
       [UISchema]="configSchema().uiSchema"
       [layout]="configSchema().layout"

--- a/ui/src/app/core/components/schema-form/schema-form.component.ts
+++ b/ui/src/app/core/components/schema-form/schema-form.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, OnInit, output, signal } from '@angular/core'
 import { JsonSchemaFormModule } from '@ng-formworks/core'
 
+import { ConfigInputComponent } from '@/app/core/components/schema-form/config-input.component'
 import { JsonSchemaFormPatchDirective } from '@/app/core/directives/json-schema-form-patch.directive'
 import { SettingsService } from '@/app/core/ui/settings.service'
 
@@ -27,6 +28,7 @@ export class SchemaFormComponent implements OnInit, OnDestroy {
 
   public readonly currentData = signal<any>(null)
   public readonly language = signal('en')
+  public readonly widgets = { text: ConfigInputComponent, password: ConfigInputComponent }
   public jsonFormOptions = {
     addSubmit: false,
     loadExternalAssets: false,

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -445,6 +445,8 @@
   "plugins.compat.node_link": "How To Update Node.js",
   "plugins.compat.node_too_low": "The {{ pluginName }} plugin recommends running on Node.js v{{ minVersion }} or later. You are currently running Node.js {{ installedVersion }}.",
   "plugins.compat.title": "Compatibility Check",
+  "plugins.config.show_value": "Show value",
+  "plugins.config.hide_value": "Hide value",
   "plugins.config.add_block": "Add new config block",
   "plugins.config.load_error": "Failed to load plugin config.",
   "plugins.config.must_be_array": "Plugin config must be an array.",


### PR DESCRIPTION
Fixes #3012

Plugin forms can expose passwords and API keys as plain text. Mask declared password fields and commonly named secret text inputs by default, with an eye button to reveal one value at a time.

Wrap the existing schema input instead of replacing its form control. Edits, validation, readonly state and saved values keep their existing behavior. Disable spelling and capitalization assistance for secret inputs. Eye buttons have accessible names and identify the input they control.

Verified on `beta-5.29.1` with 3 focused renderer tests, 4,093 UI tests, 798 server tests, lint, the production build and all 14 Monaco build modules. The isolated synthetic plugin journey covers independent reveal, keyboard controls, invalid input, editing, save integrity, reopening, desktop and mobile dark mode, and desktop light mode with zero meaningful browser errors.

The schema library still logs its existing warning for `format: password`; required and minimum length validation pass. Detection is a naming heuristic for single line text inputs, plus explicit password fields. Unusual names, multiline values and custom plugin HTML are outside this change. It does not encrypt credentials.

![Masked plugin fields](https://raw.githubusercontent.com/msrivas-7/homebridge-config-ui-x/71d51908/.contributions/screenshots/plugin-secrets-masked.png)

![One synthetic value revealed](https://raw.githubusercontent.com/msrivas-7/homebridge-config-ui-x/71d51908/.contributions/screenshots/plugin-one-secret-revealed.png)

Happy to adjust the field detection rules or interaction based on feedback.
