### PR TITLE
Fix Smart Automations initial configuration load

### DIFF
--- a/ui/src/app/modules/smart-automations/smart-automation-form/smart-automation-form.component.spec.ts
+++ b/ui/src/app/modules/smart-automations/smart-automation-form/smart-automation-form.component.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from '@angular/core/testing'
+import { describe, expect, it } from 'vitest'
+
+import { ServiceTypeX, SmartAutomation } from '@/app/core/accessories/accessories.interfaces'
+import { SmartAutomationFormComponent } from '@/app/modules/smart-automations/smart-automation-form/smart-automation-form.component'
+
+function publishedLight(automationId: string): ServiceTypeX {
+  return {
+    type: 'Lightbulb',
+    accessoryInformation: {
+      'Manufacturer': 'homebridge-config-ui-x',
+      'Serial Number': automationId,
+    },
+    serviceCharacteristics: [],
+  } as unknown as ServiceTypeX
+}
+
+describe('smartAutomationFormComponent', () => {
+  it('excludes only the accessory published by the automation being edited', () => {
+    const fixture = TestBed.createComponent(SmartAutomationFormComponent)
+    fixture.componentRef.setInput('draft', {
+      id: 'automation-1',
+      type: 'smart-light-group',
+    } satisfies Partial<SmartAutomation>)
+    fixture.detectChanges()
+
+    expect(fixture.componentInstance.isSourceSelectable(publishedLight('automation-1'), 'smart-light-group')).toBe(false)
+    expect(fixture.componentInstance.isSourceSelectable(publishedLight('automation-2'), 'smart-light-group')).toBe(true)
+  })
+
+  it('does not exclude published accessories while creating a new automation', () => {
+    const fixture = TestBed.createComponent(SmartAutomationFormComponent)
+    fixture.componentRef.setInput('draft', { type: 'smart-light-group' } satisfies Partial<SmartAutomation>)
+    fixture.detectChanges()
+
+    expect(fixture.componentInstance.isSourceSelectable(publishedLight('automation-1'), 'smart-light-group')).toBe(true)
+  })
+})

--- a/ui/src/app/modules/smart-automations/smart-automation-form/smart-automation-form.component.ts
+++ b/ui/src/app/modules/smart-automations/smart-automation-form/smart-automation-form.component.ts
@@ -83,7 +83,7 @@ export class SmartAutomationFormComponent {
   }
 
   public isSourceSelectable(service: ServiceTypeX, type: SmartAutomation['type'] | undefined): boolean {
-    if (!this.isSelectable(service.type, type)) {
+    if (!this.isSelectable(service.type, type) || this.isOwnPublishedAccessory(service)) {
       return false
     }
     const requiredCharacteristic = type === 'humidity-control'
@@ -110,8 +110,24 @@ export class SmartAutomationFormComponent {
   }
 
   public isControlTarget(service: ServiceTypeX): boolean {
-    return ['Switch', 'Outlet', 'Fan', 'Fanv2', 'HeaterCooler', 'Thermostat', 'AirPurifier'].includes(service.type || '')
+    return !this.isOwnPublishedAccessory(service)
+      && ['Switch', 'Outlet', 'Fan', 'Fanv2', 'HeaterCooler', 'Thermostat', 'AirPurifier'].includes(service.type || '')
       && service.serviceCharacteristics.some(characteristic => characteristic.canWrite && ['On', 'Active', 'TargetHeatingCoolingState'].includes(characteristic.type))
+  }
+
+  /**
+   * Prevent an automation from consuming its own published accessory, which
+   * would create a feedback loop. Outputs from every other automation remain
+   * selectable so rules can intentionally be chained together.
+   * @param service - a discovered Homebridge service
+   */
+  private isOwnPublishedAccessory(service: ServiceTypeX): boolean {
+    const automationId = this.draft().id
+    return Boolean(
+      automationId
+      && service.accessoryInformation?.Manufacturer === 'homebridge-config-ui-x'
+      && service.accessoryInformation?.['Serial Number'] === automationId,
+    )
   }
 
   public canSave(): boolean {

--- a/ui/src/app/modules/smart-automations/smart-automation-list/smart-automation-list.component.html
+++ b/ui/src/app/modules/smart-automations/smart-automation-list/smart-automation-list.component.html
@@ -7,7 +7,13 @@
       </div>
     </div>
 
-    @if (!automations().length) {
+    @if (loading()) {
+      <div class="automation-empty text-center" role="status" aria-live="polite">
+        <span class="spinner-border spinner-border-sm mb-3" aria-hidden="true"></span>
+        <h6>Loading automations</h6>
+        <p class="text-muted small mb-0">Reading your saved Smart Automation configuration.</p>
+      </div>
+    } @else if (!automations().length) {
       <div class="automation-empty text-center">
         <i class="fas fa-wand-magic-sparkles mb-3" aria-hidden="true"></i>
         <h6>No automations yet</h6>

--- a/ui/src/app/modules/smart-automations/smart-automation-list/smart-automation-list.component.ts
+++ b/ui/src/app/modules/smart-automations/smart-automation-list/smart-automation-list.component.ts
@@ -11,6 +11,7 @@ import { SmartAutomation } from '@/app/core/accessories/accessories.interfaces'
 })
 export class SmartAutomationListComponent {
   public readonly automations = input<SmartAutomation[]>([])
+  public readonly loading = input(false)
   public readonly setEnabled = output<{ automation: SmartAutomation, enabled: boolean }>()
   public readonly edit = output<SmartAutomation>()
   public readonly delete = output<string>()

--- a/ui/src/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component.html
+++ b/ui/src/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component.html
@@ -20,6 +20,17 @@
       <i class="fas fa-code" aria-hidden="true"></i>
       {{ 'plugins.manage.json_config' | translate }}
     </button>
+    @if (!disabled()) {
+      <button type="button" ngbDropdownItem (click)="disablePlugin()">
+        <i class="far fa-circle-pause" aria-hidden="true"></i>
+        {{ 'plugins.manage.disable' | translate }}
+      </button>
+    } @else {
+      <button type="button" ngbDropdownItem (click)="enablePlugin()">
+        <i class="far fa-circle-play" aria-hidden="true"></i>
+        {{ 'plugins.manage.enable' | translate }}
+      </button>
+    }
     @if (bridgeUsername()) {
       <div class="dropdown-divider"></div>
       <button type="button" ngbDropdownItem (click)="childBridgeAction('restart')">

--- a/ui/src/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component.html
+++ b/ui/src/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component.html
@@ -1,0 +1,49 @@
+<div ngbDropdown placement="bottom-end" class="smart-automation-menu">
+  <button
+    type="button"
+    class="btn btn-link primary-text p-2 dropdown-toggle-no-outline"
+    ngbDropdownToggle
+    [attr.aria-label]="'plugins.button_actions' | translate"
+  >
+    <i class="fas fa-ellipsis-v fa-lg" aria-hidden="true"></i>
+  </button>
+  <div ngbDropdownMenu>
+    <button type="button" ngbDropdownItem (click)="openSettings()">
+      <i class="fas fa-sliders" aria-hidden="true"></i>
+      {{ 'plugins.button_settings' | translate }}
+    </button>
+    <button type="button" ngbDropdownItem (click)="viewLogs()">
+      <i class="fas fa-wave-square" aria-hidden="true"></i>
+      {{ 'plugins.manage.plugin_logs' | translate }}
+    </button>
+    <button type="button" ngbDropdownItem (click)="openJsonEditor()">
+      <i class="fas fa-code" aria-hidden="true"></i>
+      {{ 'plugins.manage.json_config' | translate }}
+    </button>
+    @if (bridgeUsername()) {
+      <div class="dropdown-divider"></div>
+      <button type="button" ngbDropdownItem (click)="childBridgeAction('restart')">
+        <i class="fas fa-power-off" aria-hidden="true"></i>
+        {{ 'child_bridge.restart' | translate }}
+      </button>
+      <button type="button" ngbDropdownItem (click)="childBridgeAction('stop')">
+        <i class="fas fa-stop" aria-hidden="true"></i>
+        {{ 'child_bridge.stop' | translate }}
+      </button>
+      <button type="button" ngbDropdownItem (click)="resetAccessories()">
+        <i class="fas fa-broom" aria-hidden="true"></i>
+        {{ 'child_bridge.reset_accessories' | translate }}
+      </button>
+    }
+    <div class="dropdown-divider"></div>
+    <a
+      ngbDropdownItem
+      rel="noopener noreferrer"
+      target="_blank"
+      href="https://github.com/homebridge/homebridge-config-ui-x/issues"
+    >
+      <i class="far fa-circle-question" aria-hidden="true"></i>
+      {{ 'support.links.issue' | translate }}
+    </a>
+  </div>
+</div>

--- a/ui/src/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component.spec.ts
+++ b/ui/src/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ManagePluginsService } from '@/app/core/plugins/manage-plugins.service'
+import { SmartAutomationMenuComponent } from '@/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component'
+import { fakeApi, fakeWs, makeSettings, modalServiceSpy } from '@/testing'
+import { provideFakes } from '@/testing/providers'
+
+describe('smartAutomationMenuComponent', () => {
+  it('opens the child bridge namespace when this is the first page visited', async () => {
+    const ws = fakeWs()
+    const childBridges = ws.namespace('child-bridges')
+    childBridges.socket.respondTo('restart-child-bridge', {})
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideFakes({ api: fakeApi(), settings: makeSettings(), ws, modal: modalServiceSpy() }),
+        {
+          provide: ManagePluginsService,
+          useValue: { jsonEditor: vi.fn(), resetChildBridges: vi.fn() },
+        },
+      ],
+    })
+    TestBed.overrideComponent(SmartAutomationMenuComponent, {
+      set: { imports: [], template: '' },
+    })
+
+    const fixture = TestBed.createComponent(SmartAutomationMenuComponent)
+    fixture.componentRef.setInput('bridgeUsername', '0E:11:22:33:44:55')
+    fixture.detectChanges()
+
+    await fixture.componentInstance.childBridgeAction('restart')
+
+    expect(ws.connectToNamespace).toHaveBeenCalledWith('child-bridges')
+    expect(childBridges.requests).toContainEqual({
+      resource: 'restart-child-bridge',
+      payload: '0E:11:22:33:44:55',
+    })
+  })
+})

--- a/ui/src/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component.ts
+++ b/ui/src/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component.ts
@@ -1,14 +1,18 @@
-import { ChangeDetectionStrategy, Component, createEnvironmentInjector, EnvironmentInjector, inject, input, output } from '@angular/core'
+import { ChangeDetectionStrategy, Component, createEnvironmentInjector, EnvironmentInjector, inject, input, model, output } from '@angular/core'
 import { NgbDropdown, NgbDropdownItem, NgbDropdownMenu, NgbDropdownToggle } from '@ng-bootstrap/ng-bootstrap/dropdown'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap/modal'
 import { TranslatePipe } from '@ngx-translate/core'
 import { firstValueFrom } from 'rxjs'
 
+import { ApiService } from '@/app/core/communication/api.service'
 import { WsService } from '@/app/core/communication/ws.service'
-import { PLUGIN_LOGS_MODAL_DATA } from '@/app/core/modal-data-tokens'
+import { ConfirmComponent } from '@/app/core/components/confirm/confirm.component'
+import { CONFIRM_MODAL_DATA, DISABLE_PLUGIN_MODAL_DATA, PLUGIN_LOGS_MODAL_DATA } from '@/app/core/modal-data-tokens'
+import { DisablePluginComponent } from '@/app/core/plugins/disable-plugin/disable-plugin.component'
 import { ChildBridge, Plugin } from '@/app/core/plugins/manage-plugins.interfaces'
 import { ManagePluginsService } from '@/app/core/plugins/manage-plugins.service'
 import { PluginLogsComponent } from '@/app/core/plugins/plugin-logs/plugin-logs.component'
+import { SettingsService } from '@/app/core/ui/settings.service'
 import { SMART_AUTOMATION_SETTINGS_DATA, SmartAutomationSettingsComponent } from '@/app/modules/smart-automations/smart-automation-settings/smart-automation-settings.component'
 
 const SMART_AUTOMATION_PLUGIN = {
@@ -30,12 +34,15 @@ const SMART_AUTOMATION_PLUGIN = {
 })
 export class SmartAutomationMenuComponent {
   private injector = inject(EnvironmentInjector)
+  private $api = inject(ApiService)
   private $modal = inject(NgbModal)
   private $plugins = inject(ManagePluginsService)
+  private $settings = inject(SettingsService)
   private $ws = inject(WsService)
 
   public readonly bridgeUsername = input('')
   public readonly debugEnabled = input(false)
+  public readonly disabled = model(false)
   public readonly debugChange = output<boolean>()
 
   public openSettings(): void {
@@ -73,7 +80,7 @@ export class SmartAutomationMenuComponent {
     void this.$plugins.jsonEditor(SMART_AUTOMATION_PLUGIN)
   }
 
-  public async childBridgeAction(action: 'restart' | 'stop'): Promise<void> {
+  public async childBridgeAction(action: 'restart' | 'start' | 'stop'): Promise<void> {
     const username = this.bridgeUsername()
     if (!username) {
       return
@@ -83,6 +90,58 @@ export class SmartAutomationMenuComponent {
       await firstValueFrom(io.request(`${action}-child-bridge`, username))
     } catch (error) {
       console.error(error)
+    }
+  }
+
+  public async disablePlugin(): Promise<void> {
+    const injector = createEnvironmentInjector([{
+      provide: DISABLE_PLUGIN_MODAL_DATA,
+      useValue: {
+        pluginName: SMART_AUTOMATION_PLUGIN.displayName,
+        isConfigured: true,
+        isConfiguredDynamicPlatform: true,
+        keepOrphans: this.$settings.keepOrphans,
+      },
+    }], this.injector)
+    const ref = this.$modal.open(DisablePluginComponent, {
+      size: 'lg',
+      backdrop: 'static',
+      injector,
+    })
+
+    try {
+      await ref.result
+      await this.$api.put('/config-editor/plugin/homebridge-smart-automation/disable', {})
+      await this.childBridgeAction('stop')
+      this.disabled.set(true)
+    } catch {
+      // The confirmation was dismissed or the update failed.
+    }
+  }
+
+  public async enablePlugin(): Promise<void> {
+    const injector = createEnvironmentInjector([{
+      provide: CONFIRM_MODAL_DATA,
+      useValue: {
+        title: SMART_AUTOMATION_PLUGIN.displayName,
+        message: 'Enable the Smart Automation engine?',
+        confirmButtonLabel: 'Enable',
+        faIconClass: 'far fa-circle-play primary-text',
+      },
+    }], this.injector)
+    const ref = this.$modal.open(ConfirmComponent, {
+      size: 'lg',
+      backdrop: 'static',
+      injector,
+    })
+
+    try {
+      await ref.result
+      await this.$api.put('/config-editor/plugin/homebridge-smart-automation/enable', {})
+      await this.childBridgeAction('start')
+      this.disabled.set(false)
+    } catch {
+      // The confirmation was dismissed or the update failed.
     }
   }
 

--- a/ui/src/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component.ts
+++ b/ui/src/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component.ts
@@ -1,0 +1,111 @@
+import { ChangeDetectionStrategy, Component, createEnvironmentInjector, EnvironmentInjector, inject, input, output } from '@angular/core'
+import { NgbDropdown, NgbDropdownItem, NgbDropdownMenu, NgbDropdownToggle } from '@ng-bootstrap/ng-bootstrap/dropdown'
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap/modal'
+import { TranslatePipe } from '@ngx-translate/core'
+import { firstValueFrom } from 'rxjs'
+
+import { WsService } from '@/app/core/communication/ws.service'
+import { PLUGIN_LOGS_MODAL_DATA } from '@/app/core/modal-data-tokens'
+import { ChildBridge, Plugin } from '@/app/core/plugins/manage-plugins.interfaces'
+import { ManagePluginsService } from '@/app/core/plugins/manage-plugins.service'
+import { PluginLogsComponent } from '@/app/core/plugins/plugin-logs/plugin-logs.component'
+import { SMART_AUTOMATION_SETTINGS_DATA, SmartAutomationSettingsComponent } from '@/app/modules/smart-automations/smart-automation-settings/smart-automation-settings.component'
+
+const SMART_AUTOMATION_PLUGIN = {
+  name: 'homebridge-smart-automation',
+  displayName: 'Smart Automation',
+  installedVersion: '',
+  isConfigured: true,
+  links: {
+    bugs: 'https://github.com/homebridge/homebridge-config-ui-x/issues',
+  },
+} as unknown as Plugin
+
+@Component({
+  selector: 'app-smart-automation-menu',
+  imports: [NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, TranslatePipe],
+  standalone: true,
+  templateUrl: './smart-automation-menu.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SmartAutomationMenuComponent {
+  private injector = inject(EnvironmentInjector)
+  private $modal = inject(NgbModal)
+  private $plugins = inject(ManagePluginsService)
+  private $ws = inject(WsService)
+
+  public readonly bridgeUsername = input('')
+  public readonly debugEnabled = input(false)
+  public readonly debugChange = output<boolean>()
+
+  public openSettings(): void {
+    const injector = createEnvironmentInjector([{
+      provide: SMART_AUTOMATION_SETTINGS_DATA,
+      useValue: {
+        debugEnabled: this.debugEnabled(),
+        save: (enabled: boolean) => this.debugChange.emit(enabled),
+      },
+    }], this.injector)
+
+    this.$modal.open(SmartAutomationSettingsComponent, {
+      backdrop: 'static',
+      injector,
+    })
+  }
+
+  public viewLogs(): void {
+    const injector = createEnvironmentInjector([{
+      provide: PLUGIN_LOGS_MODAL_DATA,
+      useValue: {
+        plugin: SMART_AUTOMATION_PLUGIN,
+        childBridges: this.childBridges(),
+      },
+    }], this.injector)
+
+    this.$modal.open(PluginLogsComponent, {
+      size: 'xl',
+      backdrop: 'static',
+      injector,
+    })
+  }
+
+  public openJsonEditor(): void {
+    void this.$plugins.jsonEditor(SMART_AUTOMATION_PLUGIN)
+  }
+
+  public async childBridgeAction(action: 'restart' | 'stop'): Promise<void> {
+    const username = this.bridgeUsername()
+    if (!username) {
+      return
+    }
+    try {
+      const io = this.$ws.getExistingNamespace('child-bridges')
+      await firstValueFrom(io.request(`${action}-child-bridge`, username))
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  public resetAccessories(): void {
+    void this.$plugins.resetChildBridges(this.childBridges())
+  }
+
+  private childBridges(): ChildBridge[] {
+    const username = this.bridgeUsername()
+    if (!username) {
+      return []
+    }
+    return [{
+      identifier: username,
+      manuallyStopped: false,
+      name: 'Smart Automation',
+      paired: false,
+      pid: 0,
+      pin: '',
+      plugin: SMART_AUTOMATION_PLUGIN.name,
+      setupUri: '',
+      status: 'unknown',
+      username,
+    }]
+  }
+}

--- a/ui/src/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component.ts
+++ b/ui/src/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component.ts
@@ -86,7 +86,9 @@ export class SmartAutomationMenuComponent {
       return
     }
     try {
-      const io = this.$ws.getExistingNamespace('child-bridges')
+      // This tab can be the first page opened after a UI restart, so the
+      // child-bridges namespace may not have been created by Plugins or Status.
+      const io = this.$ws.connectToNamespace('child-bridges')
       await firstValueFrom(io.request(`${action}-child-bridge`, username))
     } catch (error) {
       console.error(error)

--- a/ui/src/app/modules/smart-automations/smart-automation-settings/smart-automation-settings.component.html
+++ b/ui/src/app/modules/smart-automations/smart-automation-settings/smart-automation-settings.component.html
@@ -1,0 +1,17 @@
+<div class="modal-header">
+  <h5 class="modal-title">Smart Automation Plugin Config</h5>
+  <button type="button" class="btn-close" aria-label="Close" (click)="dismiss()"></button>
+</div>
+<div class="modal-body">
+  <div class="form-check form-switch">
+    <input id="smart-automation-debug" type="checkbox" class="form-check-input" [(ngModel)]="debugEnabled" />
+    <label class="form-check-label" for="smart-automation-debug">
+      Debug logging
+      <small class="text-muted d-block">Include detailed rule evaluation and accessory changes in the log.</small>
+    </label>
+  </div>
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-elegant" (click)="dismiss()">Cancel</button>
+  <button type="button" class="btn btn-primary" (click)="save()">Save</button>
+</div>

--- a/ui/src/app/modules/smart-automations/smart-automation-settings/smart-automation-settings.component.ts
+++ b/ui/src/app/modules/smart-automations/smart-automation-settings/smart-automation-settings.component.ts
@@ -1,0 +1,33 @@
+import { ChangeDetectionStrategy, Component, inject, InjectionToken } from '@angular/core'
+import { FormsModule } from '@angular/forms'
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal'
+
+interface SmartAutomationSettingsData {
+  debugEnabled: boolean
+  save: (enabled: boolean) => void
+}
+
+export const SMART_AUTOMATION_SETTINGS_DATA = new InjectionToken<SmartAutomationSettingsData>('SmartAutomationSettingsData')
+
+@Component({
+  selector: 'app-smart-automation-settings',
+  imports: [FormsModule],
+  standalone: true,
+  templateUrl: './smart-automation-settings.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SmartAutomationSettingsComponent {
+  private $activeModal = inject(NgbActiveModal)
+  private data = inject(SMART_AUTOMATION_SETTINGS_DATA)
+
+  public debugEnabled = this.data.debugEnabled
+
+  public save(): void {
+    this.data.save(this.debugEnabled)
+    this.$activeModal.close()
+  }
+
+  public dismiss(): void {
+    this.$activeModal.dismiss()
+  }
+}

--- a/ui/src/app/modules/smart-automations/smart-automations.component.html
+++ b/ui/src/app/modules/smart-automations/smart-automations.component.html
@@ -14,20 +14,13 @@
       <strong>{{ smartAutomations().length }}</strong>
       <span>{{ smartAutomations().length === 1 ? 'automation' : 'automations' }}</span>
     </div>
-    <div class="debug-toggle form-check form-switch mb-0">
-      <input
-        id="smart-automation-debug"
-        type="checkbox"
-        class="form-check-input"
-        [checked]="debugEnabled()"
-        [disabled]="!isAdmin"
-        (change)="onDebugLoggingChange($event)"
+    @if (isAdmin) {
+      <app-smart-automation-menu
+        [bridgeUsername]="childBridgeUsername()"
+        [debugEnabled]="debugEnabled()"
+        (debugChange)="setDebugLogging($event)"
       />
-      <label class="form-check-label" for="smart-automation-debug">
-        Debug logging
-        <small class="text-muted d-block">Applies after restart</small>
-      </label>
-    </div>
+    }
   </div>
 
   <div class="row g-3 align-items-start">

--- a/ui/src/app/modules/smart-automations/smart-automations.component.html
+++ b/ui/src/app/modules/smart-automations/smart-automations.component.html
@@ -18,7 +18,9 @@
       <app-smart-automation-menu
         [bridgeUsername]="childBridgeUsername()"
         [debugEnabled]="debugEnabled()"
+        [disabled]="pluginDisabled()"
         (debugChange)="setDebugLogging($event)"
+        (disabledChange)="pluginDisabled.set($event)"
       />
     }
   </div>

--- a/ui/src/app/modules/smart-automations/smart-automations.component.html
+++ b/ui/src/app/modules/smart-automations/smart-automations.component.html
@@ -34,6 +34,7 @@
     <div class="col-xl-4 col-lg-5">
       <app-smart-automation-list
         [automations]="smartAutomations()"
+        [loading]="automationsLoading()"
         (setEnabled)="setSmartAutomationEnabled($event.automation, $event.enabled)"
         (edit)="editSmartAutomation($event)"
         (delete)="deleteSmartAutomation($event)"

--- a/ui/src/app/modules/smart-automations/smart-automations.component.scss
+++ b/ui/src/app/modules/smart-automations/smart-automations.component.scss
@@ -43,29 +43,13 @@
   }
 }
 
-.debug-toggle {
-  padding-left: 2.75rem;
-  white-space: nowrap;
-
-  .form-check-input {
-    width: 2.2rem;
-    height: 1.15rem;
-    margin-left: -2.75rem;
-  }
-
-  small {
-    font-size: 0.7rem;
-  }
-}
-
 @media (max-width: 575.98px) {
   .smart-automation-hero {
     align-items: flex-start;
     padding: 1rem;
   }
 
-  .automation-count,
-  .debug-toggle {
+  .automation-count {
     display: none;
   }
 }

--- a/ui/src/app/modules/smart-automations/smart-automations.component.spec.ts
+++ b/ui/src/app/modules/smart-automations/smart-automations.component.spec.ts
@@ -1,0 +1,52 @@
+import { NO_ERRORS_SCHEMA, signal } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AccessoriesService } from '@/app/core/accessories/accessories.service'
+import { SmartAutomationsComponent } from '@/app/modules/smart-automations/smart-automations.component'
+import { fakeApi, makeAuth, makeSettings } from '@/testing'
+import { provideFakes } from '@/testing/providers'
+
+describe('smartAutomationsComponent', () => {
+  it('loads saved automations without waiting for accessory discovery', async () => {
+    const api = fakeApi().respond('get', '/config-editor/plugin/smart-automation', [{
+      platform: 'smart-automation',
+      smartAutomations: [{
+        id: 'automation-1',
+        name: 'Dining Room',
+        type: 'smart-light-group',
+        uniqueIds: ['light-1'],
+        enabled: true,
+      }],
+    }])
+    const accessories = {
+      rooms: signal([]),
+      start: vi.fn(() => new Promise<void>(() => {})),
+      stop: vi.fn(),
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideFakes({
+          api,
+          auth: makeAuth({ user: { admin: true } }),
+          settings: makeSettings(),
+        }),
+        { provide: AccessoriesService, useValue: accessories },
+      ],
+    })
+    TestBed.overrideComponent(SmartAutomationsComponent, {
+      set: { imports: [], schemas: [NO_ERRORS_SCHEMA] },
+    })
+
+    const fixture = TestBed.createComponent(SmartAutomationsComponent)
+    fixture.detectChanges()
+    await Promise.resolve()
+
+    expect(accessories.start).toHaveBeenCalledOnce()
+    expect(api.callsTo('get', '/config-editor/plugin/smart-automation')).toHaveLength(1)
+    expect(fixture.componentInstance.smartAutomations()).toEqual([
+      expect.objectContaining({ id: 'automation-1', name: 'Dining Room' }),
+    ])
+  })
+})

--- a/ui/src/app/modules/smart-automations/smart-automations.component.spec.ts
+++ b/ui/src/app/modules/smart-automations/smart-automations.component.spec.ts
@@ -9,16 +9,9 @@ import { provideFakes } from '@/testing/providers'
 
 describe('smartAutomationsComponent', () => {
   it('loads saved automations without waiting for accessory discovery', async () => {
-    const api = fakeApi().respond('get', '/config-editor/plugin/smart-automation', [{
-      platform: 'smart-automation',
-      smartAutomations: [{
-        id: 'automation-1',
-        name: 'Dining Room',
-        type: 'smart-light-group',
-        uniqueIds: ['light-1'],
-        enabled: true,
-      }],
-    }])
+    let finishConfigLoad!: (value: any) => void
+    const configLoad = new Promise(resolve => finishConfigLoad = resolve)
+    const api = fakeApi().respond('get', '/config-editor/plugin/smart-automation', configLoad)
     const accessories = {
       rooms: signal([]),
       start: vi.fn(() => new Promise<void>(() => {})),
@@ -41,10 +34,24 @@ describe('smartAutomationsComponent', () => {
 
     const fixture = TestBed.createComponent(SmartAutomationsComponent)
     fixture.detectChanges()
+
+    expect(fixture.componentInstance.automationsLoading()).toBe(true)
+    finishConfigLoad([{
+      platform: 'smart-automation',
+      smartAutomations: [{
+        id: 'automation-1',
+        name: 'Dining Room',
+        type: 'smart-light-group',
+        uniqueIds: ['light-1'],
+        enabled: true,
+      }],
+    }])
+    await Promise.resolve()
     await Promise.resolve()
 
     expect(accessories.start).toHaveBeenCalledOnce()
     expect(api.callsTo('get', '/config-editor/plugin/smart-automation')).toHaveLength(1)
+    expect(fixture.componentInstance.automationsLoading()).toBe(false)
     expect(fixture.componentInstance.smartAutomations()).toEqual([
       expect.objectContaining({ id: 'automation-1', name: 'Dining Room' }),
     ])

--- a/ui/src/app/modules/smart-automations/smart-automations.component.spec.ts
+++ b/ui/src/app/modules/smart-automations/smart-automations.component.spec.ts
@@ -11,7 +11,7 @@ describe('smartAutomationsComponent', () => {
   it('loads saved automations without waiting for accessory discovery', async () => {
     let finishConfigLoad!: (value: any) => void
     const configLoad = new Promise(resolve => finishConfigLoad = resolve)
-    const api = fakeApi().respond('get', '/config-editor/plugin/smart-automation', configLoad)
+    const api = fakeApi().respond('get', '/config-editor/plugin/smart-automation', configLoad).respond('get', '/config-editor', { disabledPlugins: [] })
     const accessories = {
       rooms: signal([]),
       start: vi.fn(() => new Promise<void>(() => {})),

--- a/ui/src/app/modules/smart-automations/smart-automations.component.ts
+++ b/ui/src/app/modules/smart-automations/smart-automations.component.ts
@@ -7,6 +7,7 @@ import { ApiService } from '@/app/core/communication/api.service'
 import { SettingsService } from '@/app/core/ui/settings.service'
 import { SmartAutomationFormComponent } from '@/app/modules/smart-automations/smart-automation-form/smart-automation-form.component'
 import { SmartAutomationListComponent } from '@/app/modules/smart-automations/smart-automation-list/smart-automation-list.component'
+import { SmartAutomationMenuComponent } from '@/app/modules/smart-automations/smart-automation-menu/smart-automation-menu.component'
 
 interface ConfigPlatformBlock {
   platform: string
@@ -28,6 +29,7 @@ const SMART_AUTOMATION_PLATFORM = 'smart-automation'
   imports: [
     SmartAutomationFormComponent,
     SmartAutomationListComponent,
+    SmartAutomationMenuComponent,
   ],
   standalone: true,
   templateUrl: './smart-automations.component.html',
@@ -43,6 +45,7 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
   public isAdmin = this.$auth.user.admin
   public readonly smartAutomations = signal<SmartAutomation[]>([])
   public readonly automationsLoading = signal(true)
+  public readonly childBridgeUsername = signal('')
   public readonly debugEnabled = signal(false)
   public readonly selectedLightUniqueIds = signal<string[]>([])
   public readonly selectedTargetUniqueId = signal('')
@@ -197,10 +200,6 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
     await this.syncSmartAutomationChildBridgeConfig()
   }
 
-  public onDebugLoggingChange(event: Event): void {
-    void this.setDebugLogging((event.target as HTMLInputElement).checked)
-  }
-
   private async loadSmartAutomationConfig(): Promise<void> {
     if (!this.isAdmin) {
       this.automationsLoading.set(false)
@@ -213,6 +212,7 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
       const switches = (smartAutomationBlock?.smartAutomations || []).filter(a => typeof a?.name === 'string')
       this.smartAutomations.set(switches)
       this.debugEnabled.set(smartAutomationBlock?.debug === true)
+      this.childBridgeUsername.set(smartAutomationBlock?._bridge?.username || '')
     } catch (error) {
       console.error(error)
     } finally {

--- a/ui/src/app/modules/smart-automations/smart-automations.component.ts
+++ b/ui/src/app/modules/smart-automations/smart-automations.component.ts
@@ -42,6 +42,7 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
 
   public isAdmin = this.$auth.user.admin
   public readonly smartAutomations = signal<SmartAutomation[]>([])
+  public readonly automationsLoading = signal(true)
   public readonly debugEnabled = signal(false)
   public readonly selectedLightUniqueIds = signal<string[]>([])
   public readonly selectedTargetUniqueId = signal('')
@@ -202,6 +203,7 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
 
   private async loadSmartAutomationConfig(): Promise<void> {
     if (!this.isAdmin) {
+      this.automationsLoading.set(false)
       return
     }
 
@@ -213,6 +215,8 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
       this.debugEnabled.set(smartAutomationBlock?.debug === true)
     } catch (error) {
       console.error(error)
+    } finally {
+      this.automationsLoading.set(false)
     }
   }
 

--- a/ui/src/app/modules/smart-automations/smart-automations.component.ts
+++ b/ui/src/app/modules/smart-automations/smart-automations.component.ts
@@ -59,8 +59,11 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
   public ngOnInit(): void {
     this.$settings.setPageTitle('Smart Automation')
 
+    // Loading the saved rules does not depend on accessory discovery. Keep
+    // these requests independent so a slow or reconnecting accessories socket
+    // cannot leave the automation list empty on the initial page load.
+    void this.loadSmartAutomationConfig()
     void this.$accessories.start()
-      .then(() => this.loadSmartAutomationConfig())
       .catch((error) => {
         console.error(error)
       })

--- a/ui/src/app/modules/smart-automations/smart-automations.component.ts
+++ b/ui/src/app/modules/smart-automations/smart-automations.component.ts
@@ -46,6 +46,7 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
   public readonly smartAutomations = signal<SmartAutomation[]>([])
   public readonly automationsLoading = signal(true)
   public readonly childBridgeUsername = signal('')
+  public readonly pluginDisabled = signal(false)
   public readonly debugEnabled = signal(false)
   public readonly selectedLightUniqueIds = signal<string[]>([])
   public readonly selectedTargetUniqueId = signal('')
@@ -67,6 +68,7 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
     // these requests independent so a slow or reconnecting accessories socket
     // cannot leave the automation list empty on the initial page load.
     void this.loadSmartAutomationConfig()
+    void this.loadSmartAutomationDisabledState()
     void this.$accessories.start()
       .catch((error) => {
         console.error(error)
@@ -217,6 +219,18 @@ export class SmartAutomationsComponent implements OnInit, OnDestroy {
       console.error(error)
     } finally {
       this.automationsLoading.set(false)
+    }
+  }
+
+  private async loadSmartAutomationDisabledState(): Promise<void> {
+    if (!this.isAdmin) {
+      return
+    }
+    try {
+      const config = await this.$api.get<{ disabledPlugins?: string[] }>('/config-editor')
+      this.pluginDisabled.set(config.disabledPlugins?.includes('homebridge-smart-automation') === true)
+    } catch (error) {
+      console.error(error)
     }
   }
 


### PR DESCRIPTION
## Summary
- load saved Smart Automation configuration independently of accessory discovery
- prevent a slow or reconnecting accessories socket from leaving the saved automation list empty
- add a regression test that keeps accessory startup pending while verifying saved rules appear

## Validation
- `npm run lint -- --no-fix`
- `NODE_OPTIONS=--localstorage-file=/private/tmp/homebridge-ui-vitest-localstorage npm test -- --no-watch --include=src/app/modules/smart-automations/smart-automations.component.spec.ts` (from `ui`)