### PR TITLE
Apply prerelease notes review fixes to alpha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,7 @@ jobs:
           name: prerelease-notes-${{ steps.get-published-version.outputs.version }}
           path: ${{ runner.temp }}/prerelease-notes.md
           retention-days: 1
+          overwrite: true
 
       - name: Build
         run: npm run build
@@ -224,7 +225,7 @@ jobs:
           tag_name: v${{ needs.publish.outputs.npm_version }}
           release_name: v${{ needs.publish.outputs.npm_version }}
           body_path: prerelease-notes.md
-          keep_num: 5
+          keep_num: 12
           keep_tags: false
 
       - name: Add GitHub pre-release summary

--- a/scripts/generate-prerelease-notes.mjs
+++ b/scripts/generate-prerelease-notes.mjs
@@ -79,8 +79,9 @@ const cumulativeSection = cumulativeNotes
   ? `\n\n## Everything included in the v${baseVersion} ${releaseLabel}\n\n${cumulativeNotes}`
   : ''
 
-const notes = `> [!WARNING]
-> This is a ${releaseLabel} test release and is not recommended for production systems.
+const notes = `
+> [!WARNING]
+> This ${releaseLabel} test release is not recommended for production systems.
 
 ## ${comparisonHeading}
 


### PR DESCRIPTION
## Summary

- start generated notes with a blank line so the GitHub warning callout renders after the release action prepends its comment
- avoid the alpha/beta article mismatch in the warning text
- allow the prerelease-notes artifact to be overwritten when a failed publish job is rerun
- retain 12 prereleases so previous alpha and beta comparison tags remain available

## Validation

- npm run lint -- --no-cache
- release workflow YAML parsed successfully
- generated an alpha preview for v6.0.1-alpha.13 using v6.0.1-alpha.12
- confirmed the alpha branch's existing commit-list fallback remains intact when no matching pending changelog section exists