### PR TITLE
Update validation to catch npm install errors

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -94,11 +94,12 @@ jobs:
         run: |
           # npm normally warns but exits successfully when dependency install scripts are
           # unreviewed. Strict mode turns that warning into a validation failure.
-          sudo npm install -g --omit=dev --strict-allow-scripts ./homebridge-config-ui-x-*.tgz homebridge
+          sudo env "PATH=$PATH" npm install -g --omit=dev --strict-allow-scripts ./homebridge-config-ui-x-*.tgz homebridge
 
           # Verify that the packed global install contains a loadable native node-pty
           # binding. This catches missing prebuilds even when npm reports success.
-          cd "$(sudo npm root -g)/homebridge-config-ui-x"
+          global_node_modules=$(sudo env "PATH=$PATH" npm root -g)
+          cd "$global_node_modules/homebridge-config-ui-x"
           node -e "require('@homebridge/node-pty-prebuilt-multiarch')"
           hb-service -v
           sudo hb-service install --user homebridge --group `id -gn`
@@ -108,11 +109,12 @@ jobs:
         run: |
           # npm normally warns but exits successfully when dependency install scripts are
           # unreviewed. Strict mode turns that warning into a validation failure.
-          sudo npm install -g --omit=dev --strict-allow-scripts ./homebridge-config-ui-x-*.tgz homebridge
+          sudo env "PATH=$PATH" npm install -g --omit=dev --strict-allow-scripts ./homebridge-config-ui-x-*.tgz homebridge
 
           # Verify that the packed global install contains a loadable native node-pty
           # binding. This catches missing prebuilds even when npm reports success.
-          cd "$(sudo npm root -g)/homebridge-config-ui-x"
+          global_node_modules=$(sudo env "PATH=$PATH" npm root -g)
+          cd "$global_node_modules/homebridge-config-ui-x"
           node -e "require('@homebridge/node-pty-prebuilt-multiarch')"
           hb-service -v
           sudo hb-service install

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -98,7 +98,7 @@ jobs:
 
           # Verify that the packed global install contains a loadable native node-pty
           # binding. This catches missing prebuilds even when npm reports success.
-          cd "$(npm root -g)/homebridge-config-ui-x"
+          cd "$(sudo npm root -g)/homebridge-config-ui-x"
           node -e "require('@homebridge/node-pty-prebuilt-multiarch')"
           hb-service -v
           sudo hb-service install --user homebridge --group `id -gn`
@@ -112,7 +112,7 @@ jobs:
 
           # Verify that the packed global install contains a loadable native node-pty
           # binding. This catches missing prebuilds even when npm reports success.
-          cd "$(npm root -g)/homebridge-config-ui-x"
+          cd "$(sudo npm root -g)/homebridge-config-ui-x"
           node -e "require('@homebridge/node-pty-prebuilt-multiarch')"
           hb-service -v
           sudo hb-service install

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -84,38 +84,62 @@ jobs:
       - run: npm run build:server
       - run: npm run test
 
-      # remove dev deps
-      - run: npm clean-install --omit=dev
+      # Pack the built package so the service is tested using the same package
+      # boundary as an npm registry installation, rather than a source link.
+      - name: Pack Homebridge UI
+        run: npm pack --ignore-scripts
 
-      # test hb-service
-      - run: node dist/bin/hb-service.js -v
       - if: runner.os == 'Linux'
         name: Run hb-service install (Linux)
         run: |
-          sudo npm link
-          sudo npm install -g --omit=dev homebridge
+          # npm normally warns but exits successfully when dependency install scripts are
+          # unreviewed. Strict mode turns that warning into a validation failure.
+          sudo npm install -g --omit=dev --strict-allow-scripts ./homebridge-config-ui-x-*.tgz homebridge
+
+          # Verify that the packed global install contains a loadable native node-pty
+          # binding. This catches missing prebuilds even when npm reports success.
+          cd "$(npm root -g)/homebridge-config-ui-x"
+          node -e "require('@homebridge/node-pty-prebuilt-multiarch')"
+          hb-service -v
           sudo hb-service install --user homebridge --group `id -gn`
           sleep 30
       - if: runner.os == 'macOS'
         name: Run hb-service install (macOS)
         run: |
-          sudo npm link
-          sudo npm install -g --omit=dev homebridge
+          # npm normally warns but exits successfully when dependency install scripts are
+          # unreviewed. Strict mode turns that warning into a validation failure.
+          sudo npm install -g --omit=dev --strict-allow-scripts ./homebridge-config-ui-x-*.tgz homebridge
+
+          # Verify that the packed global install contains a loadable native node-pty
+          # binding. This catches missing prebuilds even when npm reports success.
+          cd "$(npm root -g)/homebridge-config-ui-x"
+          node -e "require('@homebridge/node-pty-prebuilt-multiarch')"
+          hb-service -v
           sudo hb-service install
           sleep 30
       - if: runner.os == 'Windows'
         name: Run hb-service install (Windows)
         run: |
-          npm link
-          npm install -g --omit=dev homebridge
+          $package = Get-Item ./homebridge-config-ui-x-*.tgz
+
+          # npm normally warns but exits successfully when dependency install scripts are
+          # unreviewed. Strict mode turns that warning into a validation failure.
+          npm install -g --omit=dev --strict-allow-scripts $package.FullName homebridge
+
+          # Verify that the packed global install contains a loadable native node-pty
+          # binding. This catches missing prebuilds even when npm reports success.
+          Push-Location (Join-Path (npm root -g) 'homebridge-config-ui-x')
+          node -e "require('@homebridge/node-pty-prebuilt-multiarch')"
+          Pop-Location
+          hb-service -v
           hb-service install
           Start-Sleep -s 30
       - name: Test hb-service install
-        run: node dist/bin/hb-service.js status --port 8581
+        run: hb-service status --port 8581
       - name: View Errors
         if: ${{ failure() }}
         run: |
-          node dist/bin/hb-service.js view
+          hb-service view
           exit 1
 
   # The UI unit tests run in jsdom, so a single platform is enough

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -102,7 +102,7 @@ jobs:
           cd "$global_node_modules/homebridge-config-ui-x"
           node -e "require('@homebridge/node-pty-prebuilt-multiarch')"
           hb-service -v
-          sudo hb-service install --user homebridge --group `id -gn`
+          sudo env "PATH=$PATH" hb-service install --user homebridge --group `id -gn`
           sleep 30
       - if: runner.os == 'macOS'
         name: Run hb-service install (macOS)
@@ -117,7 +117,7 @@ jobs:
           cd "$global_node_modules/homebridge-config-ui-x"
           node -e "require('@homebridge/node-pty-prebuilt-multiarch')"
           hb-service -v
-          sudo hb-service install
+          sudo env "PATH=$PATH" hb-service install
           sleep 30
       - if: runner.os == 'Windows'
         name: Run hb-service install (Windows)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -92,9 +92,9 @@ jobs:
       - if: runner.os == 'Linux'
         name: Run hb-service install (Linux)
         run: |
-          # npm normally warns but exits successfully when dependency install scripts are
-          # unreviewed. Strict mode turns that warning into a validation failure.
-          sudo env "PATH=$PATH" npm install -g --omit=dev --strict-allow-scripts ./homebridge-config-ui-x-*.tgz homebridge
+          # Global installs do not inherit allowScripts from a dependency's package.json,
+          # so explicitly allow the lifecycle scripts required by Homebridge UI.
+          sudo env "PATH=$PATH" npm install -g --omit=dev --allow-scripts=homebridge-config-ui-x,@homebridge/node-pty-prebuilt-multiarch,macos-temperature-sensor,osx-temperature-sensor ./homebridge-config-ui-x-*.tgz homebridge
 
           # Verify that the packed global install contains a loadable native node-pty
           # binding. This catches missing prebuilds even when npm reports success.
@@ -107,9 +107,9 @@ jobs:
       - if: runner.os == 'macOS'
         name: Run hb-service install (macOS)
         run: |
-          # npm normally warns but exits successfully when dependency install scripts are
-          # unreviewed. Strict mode turns that warning into a validation failure.
-          sudo env "PATH=$PATH" npm install -g --omit=dev --strict-allow-scripts ./homebridge-config-ui-x-*.tgz homebridge
+          # Global installs do not inherit allowScripts from a dependency's package.json,
+          # so explicitly allow the lifecycle scripts required by Homebridge UI.
+          sudo env "PATH=$PATH" npm install -g --omit=dev --allow-scripts=homebridge-config-ui-x,@homebridge/node-pty-prebuilt-multiarch,macos-temperature-sensor,osx-temperature-sensor ./homebridge-config-ui-x-*.tgz homebridge
 
           # Verify that the packed global install contains a loadable native node-pty
           # binding. This catches missing prebuilds even when npm reports success.
@@ -124,9 +124,9 @@ jobs:
         run: |
           $package = Get-Item ./homebridge-config-ui-x-*.tgz
 
-          # npm normally warns but exits successfully when dependency install scripts are
-          # unreviewed. Strict mode turns that warning into a validation failure.
-          npm install -g --omit=dev --strict-allow-scripts $package.FullName homebridge
+          # Global installs do not inherit allowScripts from a dependency's package.json,
+          # so explicitly allow the lifecycle scripts required by Homebridge UI.
+          npm install -g --omit=dev --allow-scripts=homebridge-config-ui-x,@homebridge/node-pty-prebuilt-multiarch,macos-temperature-sensor,osx-temperature-sensor $package.FullName homebridge
 
           # Verify that the packed global install contains a loadable native node-pty
           # binding. This catches missing prebuilds even when npm reports success.


### PR DESCRIPTION
Looking at Issue #3021, a command line install will not work if it is installed into a different directory ie with -g, and installs need to include allowScripts.

This PR updates the validation workflow to recreate the install issue, and then includes the fix.  This is being done to detect further NPM changes that potentially break the install process.

PS The wiki's have already been updated with the updated install command.

https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-macOS#step-2-install-homebridge-and-homebridge-ui